### PR TITLE
Conditionally show search results container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/search-form/index.js
+++ b/source/components/search-form/index.js
@@ -83,9 +83,11 @@ class SearchForm extends Component {
             />
           </div>
         </div>
-        <div className={classNames.results}>
-          {children}
-        </div>
+        {children && (
+          <div className={classNames.results}>
+            {children}
+          </div>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
Even when there were no search results, it was still rendering that
containing div, meaning there was an awkward padding below the form.