### PR TITLE
Add element as supported proptype

### DIFF
--- a/source/components/metric/index.js
+++ b/source/components/metric/index.js
@@ -38,7 +38,10 @@ Metric.propTypes = {
   /**
   * The actual amount
   */
-  amount: PropTypes.string.isRequired,
+  amount: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ]).isRequired,
 
   /**
   * The icon to display above the metric


### PR DESCRIPTION
Constructicon throws a type warning when metrics are in loading state due to the `amount` prop being React components