### PR TITLE
Ability to add padding within a container

### DIFF
--- a/source/components/container/index.js
+++ b/source/components/container/index.js
@@ -35,6 +35,14 @@ Container.propTypes = {
   width: PropTypes.number,
 
   /**
+  * The internal padding to be applied
+  */
+  spacing: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.number
+  ]),
+
+  /**
   * Sets the min-height to the height of the viewport
   */
   fullHeight: PropTypes.bool,
@@ -68,6 +76,7 @@ Container.propTypes = {
 Container.defaultProps = {
   tag: 'article',
   width: 40,
+  spacing: 0,
   styles: {}
 }
 

--- a/source/components/container/styles.js
+++ b/source/components/container/styles.js
@@ -1,5 +1,6 @@
 export default (props, traits) => {
   const {
+    calculateSpacing,
     colors,
     rhythm,
     shadows,
@@ -13,6 +14,7 @@ export default (props, traits) => {
     outerColor,
     styles,
     width,
+    spacing,
     fullHeight
   } = props
 
@@ -21,6 +23,7 @@ export default (props, traits) => {
       maxWidth: rhythm(width, 'em'),
       minHeight: fullHeight && '100vh',
       margin: '0 auto',
+      ...calculateSpacing(spacing),
       backgroundColor: background && colors[background],
       color: foreground && colors[foreground],
       ...treatments.body,


### PR DESCRIPTION
*Problem*

There was no option to apply any padding within a container, and you
would have to use a Section or apply custom styles.

*Solution*

You can now add a spacing prop in the same way you can on various other
components e.g. spacing={1}, spacing={{ x: 1, y: 0.5 }} etc.