### PR TITLE
Fix flex css issue for IE (leaderboards)

### DIFF
--- a/source/components/leaderboard-item/styles.js
+++ b/source/components/leaderboard-item/styles.js
@@ -51,7 +51,7 @@ export default (props, traits) => {
     },
 
     info: {
-      flex: '0 1 auto',
+      flex: 1,
       minWidth: 0
     },
 
@@ -73,7 +73,7 @@ export default (props, traits) => {
     },
 
     amount: {
-      flex: 1,
+      flex: '0 0 auto',
       paddingLeft: rhythm(0.5),
       paddingRight: rhythm(0.5),
       textAlign: 'right',

--- a/source/components/leaderboard/Readme.md
+++ b/source/components/leaderboard/Readme.md
@@ -36,7 +36,7 @@ const leader = {
   href: 'http://google.com',
   image: 'http://placehold.it/250x250',
   name: 'Leader Name',
-  charity: 'Charity Name',
+  charity: 'Charity name that is actually rather long',
   amount: '$1,500'
 };
 


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/729085/24732695/d08c9162-1ab5-11e7-9c9d-364fd2c284ec.png)
After:
![after](https://cloud.githubusercontent.com/assets/729085/24732696/d08f3e26-1ab5-11e7-8882-db1bcab88fb5.png)
