### PR TITLE
Fix IE styling issue with grid container

### DIFF
--- a/source/components/grid/styles.js
+++ b/source/components/grid/styles.js
@@ -19,6 +19,7 @@ export default (props, traits) => {
   return {
     root: {
       display: 'flex',
+      width: '100%',
       flexWrap: 'wrap',
       alignItems: props.align,
       justifyContent: props.justify,


### PR DESCRIPTION
Before:
![screen shot 2017-05-26 at 2 56 24 pm](https://cloud.githubusercontent.com/assets/729085/26481307/82d0f05e-4223-11e7-8590-cbf3ed7f4165.png)

After:
![screen shot 2017-05-26 at 2 57 17 pm](https://cloud.githubusercontent.com/assets/729085/26481316/a10cb9c2-4223-11e7-8718-9f9db1ecbf09.png)
