### PR TITLE
Cross-browser InputSelect consistent styling.

### DIFF
--- a/source/components/form/Readme.md
+++ b/source/components/form/Readme.md
@@ -58,6 +58,11 @@ handleSubmit = (e) => {
       value={state.source}
       options={[
         {
+          label: 'Select an option...',
+          value: '',
+          disabled: true
+        },
+        {
           label: 'The Internet',
           value: 'web'
         },
@@ -88,7 +93,7 @@ handleSubmit = (e) => {
     <p style={{ padding: '1rem', background: 'whitesmoke' }}>
       Email: {state.email || 'N/A'} <br />
       Password: {Array.from(Array(state.password.length)).map((x, i) => { return '*' }).join('')} <br />
-      Source: {state.source || 'N/A'} 
+      Source: {state.source || 'N/A'}
     </p>
   )}
 </div>

--- a/source/components/input-field/styles.js
+++ b/source/components/input-field/styles.js
@@ -63,7 +63,7 @@ export default (props, traits) => {
       minHeight: textarea && rhythm(4),
       maxHeight: textarea && rhythm(10),
       border: `thin solid ${invalid ? colors.danger : colors.lightGrey}`,
-      boxShadow: invalid && `0 0 15px ${colors.danger}`,
+      boxShadow: invalid ? `0 0 5px ${colors.danger}` : 'none',
       borderRadius: rhythm(radiuses.small),
       ...treatments.input,
       ...styles,

--- a/source/components/input-select/index.js
+++ b/source/components/input-select/index.js
@@ -4,6 +4,8 @@ import omit from 'lodash/omit'
 import { withStyles } from '../../lib/css'
 import styles from './styles'
 
+import Icon from '../icon'
+
 const InputSelect = ({
   label,
   name,
@@ -16,6 +18,7 @@ const InputSelect = ({
   error,
   validations,
   classNames,
+  styles,
   ...props
 }) => {
   const propsBlacklist = ['children', 'dirty', 'initial', 'invalid', 'styles', 'touched', 'validators']
@@ -23,24 +26,33 @@ const InputSelect = ({
 
   return (
     <div className={classNames.root}>
-      <label className={classNames.label}>
-        {label}
-        <span className={classNames.required}>*</span>
-      </label>
-      <select
-        name={name}
-        value={value}
-        placeholder={placeholder}
-        onChange={(e) => onChange && onChange(e.target.value)}
-        onBlur={(e) => onBlur && onBlur(e.target.value)}
-        className={classNames.field}
-        required
-        {...allowedProps}>
-        {placeholder && <option>{placeholder}</option>}
-        {options.map(({ value, label }, index) => (
-          <option value={value} key={index}>{label}</option>
-        ))}
-      </select>
+      {label && (
+        <label className={classNames.label}>
+          {label}
+          {required && <span className={classNames.required}>*</span>}
+        </label>
+      )}
+
+      <div className={classNames.wrapper}>
+        <select
+          name={name}
+          value={value}
+          placeholder={placeholder}
+          onChange={(e) => onChange && onChange(e.target.value)}
+          onBlur={(e) => onBlur && onBlur(e.target.value)}
+          className={classNames.input}
+          required
+          {...allowedProps}>
+          {placeholder && <option>{placeholder}</option>}
+          {options.map(({ value, label, disabled }, index) => (
+            <option value={value} key={index} disabled={disabled}>{label}</option>
+          ))}
+        </select>
+
+        <span className={classNames.field} />
+
+        <Icon name='dropdown' size={0.75} styles={styles.icon} />
+      </div>
 
       {error && (
         <div className={classNames.errors}>

--- a/source/components/input-select/styles.js
+++ b/source/components/input-select/styles.js
@@ -42,22 +42,73 @@ export default (props, traits) => {
       color: colors.danger
     },
 
-    field: {
+    wrapper: {
+      position: 'relative',
+      'select::-ms-expand': {
+        display: 'none'
+      },
+      'select::-ms-value': {
+        background: 'none',
+        color: props.readOnly ? colors.lightGrey : colors.dark
+      },
+      'select:-moz-focusring': {
+        color: 'transparent',
+        textShadow: '0 0 0 #000'
+      }
+    },
+
+    input: {
       display: 'block',
+      position: 'relative',
+      zIndex: 1,
       width: '100%',
       textAlign: 'left',
-      backgroundColor: colors.light,
       height: rhythm(1.666),
+      lineHeight: rhythm(1.666),
+      paddingLeft: rhythm(0.333),
+      paddingRight: rhythm(1.25),
+      borderRadius: rhythm(radiuses.small),
+      border: 0,
+      backgroundColor: 'transparent',
+      backgroundImage: 'none',
+      boxShadow: 'none',
+      appearance: 'none',
+      outline: 'none',
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+      textOverflow: 'ellipsis',
+      ...treatments.input,
+      ':focus': {
+        border: 0,
+        outline: 0
+      },
+      ':focus + span': {
+        borderColor: invalid ? colors.danger : colors.secondary,
+        boxShadow: `0 0 5px ${invalid ? colors.danger : colors.secondary}`
+      }
+    },
+
+    field: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      zIndex: 0,
+      backgroundColor: colors.light,
+      color: props.readOnly ? colors.lightGrey : colors.dark,
       border: `thin solid ${invalid ? colors.danger : colors.lightGrey}`,
       boxShadow: invalid && `0 0 5px ${colors.danger}`,
       borderRadius: rhythm(radiuses.small),
       ...treatments.input,
-      ...styles,
+      ...styles
+    },
 
-      ':focus': {
-        borderColor: invalid ? colors.danger : colors.secondary,
-        boxShadow: `0 0 5px ${invalid ? colors.danger : colors.secondary}`
-      }
+    icon: {
+      position: 'absolute',
+      top: '50%',
+      right: rhythm(0.333),
+      transform: 'translateY(-50%)'
     },
 
     error: {


### PR DESCRIPTION
- Also fix some inconsistencies with input/select styles

Screens:

**iOS**
![ios-old](https://user-images.githubusercontent.com/729085/27070623-254b1d68-505d-11e7-9703-fd4b8a80134c.png) ![ios-new](https://user-images.githubusercontent.com/729085/27070622-254a261a-505d-11e7-8da2-06e0a6a48d20.png)

**Chrome**
![chrome-old](https://user-images.githubusercontent.com/729085/27070620-25470f8e-505d-11e7-8c3b-193c056ab58d.png) ![chrome-new](https://user-images.githubusercontent.com/729085/27070625-25565b4c-505d-11e7-84ab-b02c86b2136f.png)

**Firefox**
![ff-old](https://user-images.githubusercontent.com/729085/27070624-254bb642-505d-11e7-96df-db06c781ae0a.png) ![ff-new](https://user-images.githubusercontent.com/729085/27070626-2573c236-505d-11e7-9154-591679f51bf0.png)

**Edge**
![edge-old](https://user-images.githubusercontent.com/729085/27070621-254a433e-505d-11e7-836e-dc3e8d933f68.png) ![edge-new](https://user-images.githubusercontent.com/729085/27070627-25760a3c-505d-11e7-868d-dd920512bac0.png)

**IE11**
![ie-old](https://user-images.githubusercontent.com/729085/27070799-c66300bc-505d-11e7-9843-15b8075de5df.png) ![ie-new](https://user-images.githubusercontent.com/729085/27070798-c662668e-505d-11e7-8950-1d8796de7f8f.png)

