### PR TITLE
Immutable fields when being marked as touch

### DIFF
--- a/source/components/with-form/index.js
+++ b/source/components/with-form/index.js
@@ -68,7 +68,7 @@ const withForm = (config) => (ComponentToWrap) => (
     }
 
     touchFields (fields) {
-      return mapValues(fields, (field) => merge(field, {
+      return mapValues(fields, (field) => merge({}, field, {
         touched: true,
         error: !isEmpty(field.validations)
       }))


### PR DESCRIPTION
**Problem**

Merge applies changes to the first object, which was originally jus the
field.

This meant that React wasn't re-rendering components that referenced
these fields directly, as although properties of the object had changed,
it was still the same object.

**Solution**

Pass in an empty object as the first param to merge, so that a new
object is returned, React will re-render, and everybody is happy.