### PR TITLE
Add configurable Leadeboard links

### DIFF
--- a/source/components/leaderboard-item/Readme.md
+++ b/source/components/leaderboard-item/Readme.md
@@ -14,6 +14,21 @@
 </Leaderboard>
 ```
 
+**Custom Link Component**
+
+```
+<Leaderboard>
+  <LeaderboardItem
+    href='http://google.com'
+    linkTag='div'
+    title='Name Here'
+    subtitle='Charity Name'
+    image='http://placehold.it/250x250'
+    amount='2,500km'
+  />
+</Leaderboard>
+```
+
 **Custom Styles**
 
 Apply custom styles to the leaderboard item

--- a/source/components/leaderboard-item/__tests__/LeaderboardItem-test.js
+++ b/source/components/leaderboard-item/__tests__/LeaderboardItem-test.js
@@ -17,4 +17,37 @@ describe('LeaderboardItem', () => {
     expect(image.length).to.eql(1)
     expect(image.prop('src')).to.eql('http://placehold.it/250x250')
   })
+
+  it('should use the supplied LinkTag', () => {
+    const MyLink = ({ children }) => (
+      <div>
+        <p>I'm special</p>
+        {children}
+      </div>
+    )
+
+    const wrapper = mount(
+      <LeaderboardItem
+        linkTag={MyLink}
+        title='Name'
+        amount='$2,500'
+      />
+    )
+
+    const customLink = wrapper.find('MyLink')
+    expect(customLink.length).to.eql(1)
+  })
+
+  it('should use the supplied link target', () => {
+    const wrapper = mount(
+      <LeaderboardItem
+        href='http://google.com'
+        title='Name'
+        target='_top'
+      />
+    )
+
+    const item = wrapper.find('a')
+    expect(item.prop('target')).to.eql('_top')
+  })
 })

--- a/source/components/leaderboard-item/index.js
+++ b/source/components/leaderboard-item/index.js
@@ -4,30 +4,50 @@ import { withStyles } from '../../lib/css'
 import styles from './styles'
 
 const LeaderboardItem = ({
+  amount,
+  classNames,
   href,
   image,
-  title,
+  linkTag: LinkTag,
   subtitle,
-  amount,
-  classNames
-}) => (
-  <li className={classNames.root}>
-    <a href={href} target='_blank' className={classNames.link}>
-      {image && <img src={image} className={classNames.image} />}
-      <div className={classNames.info}>
-        <div className={classNames.title}>{title}</div>
-        {subtitle && <div className={classNames.subtitle}>{subtitle}</div>}
-      </div>
-      {amount && <div className={classNames.amount}>{amount}</div>}
-    </a>
-  </li>
-)
+  target,
+  title
+}) => {
+  return (
+    <li className={classNames.root}>
+      <LinkTag href={href} target={target}>
+        <div className={classNames.link}>
+          {image && <img src={image} className={classNames.image} />}
+          <div className={classNames.info}>
+            <div className={classNames.title}>{title}</div>
+            {subtitle && <div className={classNames.subtitle}>{subtitle}</div>}
+          </div>
+          {amount && <div className={classNames.amount}>{amount}</div>}
+        </div>
+      </LinkTag>
+    </li>
+  )
+}
 
 LeaderboardItem.propTypes = {
   /**
-  * The url of the leader's page
+  * The tag or component to be used as the link. e.g. `a`, React Router `Link`
+  */
+  linkTag: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element,
+    PropTypes.func
+  ]),
+
+  /**
+  * The url of the leader's page. Passed to linkTag as `href` prop
   */
   href: PropTypes.string,
+
+  /**
+  * The target for the link. e.g. `_blank`
+  */
+  target: PropTypes.string,
 
   /**
   * The avatar for the leader
@@ -61,6 +81,8 @@ LeaderboardItem.propTypes = {
 }
 
 LeaderboardItem.defaultProps = {
+  linkTag: 'a',
+  target: '_blank',
   href: '#',
   styles: {}
 }

--- a/source/components/typekit/__tests__/Typekit-test.js
+++ b/source/components/typekit/__tests__/Typekit-test.js
@@ -3,7 +3,7 @@ import Typekit from '..'
 describe('Typekit', () => {
   const getMountedElement = (el) => utils.getMountedElement(el, 'script')
 
-  it.only('should render a Typekit script', () => {
+  it('should render a Typekit script', () => {
     const typekit = getMountedElement(<Typekit id='abc123' />)
     expect(typekit.text()).to.contain('abc123')
   })


### PR DESCRIPTION
As we have more dynamically driven routes, we need to have greater control over how we link to them. This PR allows you to configure the component used within a LeaderboardItem's link, meaning you can use something like a React Router `Link` component, or whatever else you feel like.