### PR TITLE
Add prop to pass through to the link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/leaderboard-item/__tests__/LeaderboardItem-test.js
+++ b/source/components/leaderboard-item/__tests__/LeaderboardItem-test.js
@@ -50,4 +50,16 @@ describe('LeaderboardItem', () => {
     const item = wrapper.find('a')
     expect(item.prop('target')).to.eql('_top')
   })
+
+  it ('applies linkProps to the link', () => {
+    const wrapper = mount(
+      <LeaderboardItem
+        linkProps={{ foo: 'bar' }}
+        title='Name'
+      />
+    )
+
+    const item = wrapper.find('a')
+    expect(item.prop('foo')).to.eql('bar')
+  })
 })

--- a/source/components/leaderboard-item/index.js
+++ b/source/components/leaderboard-item/index.js
@@ -9,13 +9,14 @@ const LeaderboardItem = ({
   href,
   image,
   linkTag: LinkTag,
+  linkProps,
   subtitle,
   target,
   title
 }) => {
   return (
     <li className={classNames.root}>
-      <LinkTag href={href} target={target}>
+      <LinkTag href={href} target={target} {...linkProps}>
         <div className={classNames.link}>
           {image && <img src={image} className={classNames.image} />}
           <div className={classNames.info}>
@@ -38,6 +39,11 @@ LeaderboardItem.propTypes = {
     PropTypes.element,
     PropTypes.func
   ]),
+
+  /**
+  * Props to be applied to the linkTag
+  */
+  linkProps: PropTypes.object,
 
   /**
   * The url of the leader's page. Passed to linkTag as `href` prop


### PR DESCRIPTION
**Problem**

`LeaderboardItem` component works nicely for opening external links i.e. a supporter page, but there are cases where we want to do other things. In this case, I want to route around my app client-side using react-router `Link` e.g. to highlight a tourer on tour tracker.

I can use the `Link` component using the existing `linkTag` prop, but it is useless, as it only applies a `href` and a `target`.

**Solution**
Just add a simple `linkProps` prop, that is just an object of props to spread onto the link. It's not overly pretty, but gives us the flexibility to do whatever we may need to do with that link.