### PR TITLE
Make the Section component more generic and flexible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/section/__tests__/Section-test.js
+++ b/source/components/section/__tests__/Section-test.js
@@ -5,7 +5,7 @@ import { colors, rhythm, radiuses } from '../../../lib/traits'
 describe('Section', () => {
   it('should render a section', () => {
     const wrapper = mount(<Section>Content here</Section>)
-    const section = wrapper.find('section')
+    const section = wrapper.find('div')
     const rule = utils.findRule(css.rules, section.props().className)
     expect(section.text()).to.eql('Content here')
     expect(rule.css).to.contain('padding-left:1.5rem')
@@ -15,14 +15,14 @@ describe('Section', () => {
   })
 
   it('should allow us to specify the tag', () => {
-    const wrapper = mount(<Section tag='div'>Content here</Section>)
-    const section = wrapper.find('div')
+    const wrapper = mount(<Section tag='section'>Content here</Section>)
+    const section = wrapper.find('section')
     expect(section.text()).to.eql('Content here')
   })
 
   it('should allow us to alter the color', () => {
     const wrapper = mount(<Section background='primary' foreground='light'>Content here</Section>)
-    const section = wrapper.find('section')
+    const section = wrapper.find('div')
     const rule = utils.findRule(css.rules, section.props().className)
     expect(rule.css).to.contain(`background-color:${colors.primary}`)
     expect(rule.css).to.contain(`color:${colors.light}`)
@@ -30,7 +30,7 @@ describe('Section', () => {
 
   it('should allow us to set the border', () => {
     const wrapper = mount(<Section borderWidth={3} radius='medium'>Content here</Section>)
-    const section = wrapper.find('section')
+    const section = wrapper.find('div')
     const rule = utils.findRule(css.rules, section.props().className)
     expect(rule.css).to.contain(`border:3px solid ${colors.shade}`)
     expect(rule.css).to.contain(`border-radius:${rhythm(radiuses.medium)}`)
@@ -38,8 +38,18 @@ describe('Section', () => {
 
   it('should allow us to pass in custom styles', () => {
     const wrapper = mount(<Section styles={{ opacity: 0.5 }}>Content here</Section>)
-    const section = wrapper.find('section')
+    const section = wrapper.find('div')
     const rule = utils.findRule(css.rules, section.props().className)
     expect(rule.css).to.contain(`opacity:0.5`)
+  })
+
+  it('applies custom margins to the element', () => {
+    const wrapper = mount(<Section margin={{ x: 2, y: 0 }}>Content Here</Section>)
+    const section = wrapper.find('div')
+    const rule = utils.findRule(css.rules, section.props().className)
+    expect(rule.css).to.contain('margin-left:3rem')
+    expect(rule.css).to.contain('margin-right:3rem')
+    expect(rule.css).to.contain('margin-top:0')
+    expect(rule.css).to.contain('margin-bottom:0')
   })
 })

--- a/source/components/section/index.js
+++ b/source/components/section/index.js
@@ -67,15 +67,24 @@ Section.propTypes = {
   ]),
 
   /**
+  * The margin to be applied
+  */
+  margin: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.number
+  ]),
+
+  /**
   * The custom styles to be applied to the section
   */
   styles: PropTypes.object
 }
 
 Section.defaultProps = {
-  tag: 'section',
+  tag: 'div',
   borderColor: 'shade',
   spacing: {x: 1, y: 1},
+  margin: 0,
   styles: {}
 }
 

--- a/source/components/section/styles.js
+++ b/source/components/section/styles.js
@@ -11,6 +11,7 @@ export default (props, traits) => {
     borderColor,
     borderWidth,
     foreground,
+    margin,
     radius,
     spacing,
     styles
@@ -19,6 +20,7 @@ export default (props, traits) => {
   return {
     root: {
       ...calculateSpacing(spacing),
+      ...calculateSpacing(margin, 'margin'),
       backgroundColor: background && colors[background],
       color: foreground && colors[foreground],
       border: borderWidth && `${borderWidth}px solid ${colors[borderColor]}`,


### PR DESCRIPTION
<Section> is constructicon's generic component, that allows us to just add a generic block with some custom padding, colors etc.

To make it more useful, I added a margin prop so we can now apply custom margin as well as the existing padding.

I also made it default to a <div> as it's use is more generic than the original <section> component.

This allows us to write less css, and instead use this component where we just need some simple spacing/padding, rather than overusing withStyles.