### PR TITLE
Modal close z index

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/modal/styles.js
+++ b/source/components/modal/styles.js
@@ -50,6 +50,7 @@ export default (props, traits) => {
 
     close: {
       position: 'absolute',
+      zIndex: 100,
       top: rhythm(0.75),
       right: rhythm(0.75)
     }


### PR DESCRIPTION
There is an issue where you sometimes can't close modals on mobile, as the close icon is not "on top". In the absence of any decent z-index convention, I have just whacked a `z-index: 100` on it.