### PR TITLE
Leaderboard item rank

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/leaderboard-item/index.js
+++ b/source/components/leaderboard-item/index.js
@@ -10,6 +10,7 @@ const LeaderboardItem = ({
   image,
   linkTag: LinkTag,
   linkProps,
+  rank,
   subtitle,
   target,
   title
@@ -18,6 +19,7 @@ const LeaderboardItem = ({
     <li className={classNames.root}>
       <LinkTag href={href} target={target} {...linkProps}>
         <div className={classNames.link}>
+          {rank && <div className={classNames.rank}>{rank}</div>}
           {image && <img src={image} className={classNames.image} />}
           <div className={classNames.info}>
             <div className={classNames.title}>{title}</div>

--- a/source/components/leaderboard-item/styles.js
+++ b/source/components/leaderboard-item/styles.js
@@ -12,6 +12,15 @@ export default (props, traits) => {
     scale
   } = traits
 
+  const rankStyles = {
+    position: 'absolute',
+    top: '50%',
+    left: rhythm(0.5),
+    height: rhythm(2),
+    lineHeight: rhythm(2),
+    marginTop: rhythm(-1)
+  }
+
   const defaultStyles = {
     root: {
       position: 'relative',
@@ -21,16 +30,13 @@ export default (props, traits) => {
       fontSize: scale(-1),
       breakInside: 'avoid',
       ':after': {
-        content: rank ? `"${rank}."` : 'counter(board) "."',
+        content: !rank && 'counter(board) "."',
         counterIncrement: 'board',
-        position: 'absolute',
-        top: '50%',
-        left: rhythm(0.5),
-        height: rhythm(2),
-        lineHeight: rhythm(2),
-        marginTop: rhythm(-1)
+        ...rankStyles
       }
     },
+
+    rank: rankStyles,
 
     link: {
       display: 'flex',


### PR DESCRIPTION
**Problem**

Using `rank` in the css, means each individual LeaderboardItem gets it's own class name, resulting in large leaderboards crashing.

**Solution**

If no rank passed in, it uses the css counter. If a rank is passed in, it uses that and adds a DOM element.

Duplicating those rank styles isn't ideal, but we need to maintain the css counter for backwards compatibility.