### PR TITLE
Silence carousel warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "0.13.12",
+  "version": "0.13.13",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/carousel/__tests__/Carousel-test.js
+++ b/source/components/carousel/__tests__/Carousel-test.js
@@ -1,4 +1,5 @@
 import Carousel from '..'
+import Arrow from '../arrow'
 
 describe('Carousel', () => {
   it('should render a simple carousel', () => {
@@ -22,5 +23,16 @@ describe('Carousel', () => {
 
     expect(wrapper.find('.slick-prev')).to.have.length(1)
     expect(wrapper.find('.slick-next')).to.have.length(1)
+  })
+})
+
+describe('Arrow', () => {
+  it('should render a simple carousel arrow', () => {
+    const wrapper = mount(
+      <Arrow direction='prev' />
+    )
+
+    expect(wrapper.find('button').prop('aria-label')).to.eql('Previous')
+    expect(wrapper.find('svg')).to.have.length(1)
   })
 })

--- a/source/components/carousel/arrow/index.js
+++ b/source/components/carousel/arrow/index.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Icon from '../../icon'
+
+const labels = {
+  prev: 'Previous',
+  next: 'Next'
+}
+
+const Arrow = ({
+  currentSlide,
+  slideCount,
+  direction,
+  ...props
+}) => (
+  <button aria-label={labels[direction]} {...props}>
+    <Icon name='chevron' rotate={direction === 'prev' ? 180 : 0} />
+  </button>
+)
+
+Arrow.propTypes = {
+  /**
+  * The direction of the arrow
+  */
+  direction: PropTypes.oneOf([
+    'prev',
+    'next'
+  ]).isRequired
+}
+
+Arrow.defaultProps = {
+  direction: 'next'
+}
+
+export default Arrow

--- a/source/components/carousel/index.js
+++ b/source/components/carousel/index.js
@@ -6,7 +6,7 @@ import compose from '../../lib/compose'
 import { withStyles } from '../../lib/css'
 import styles from './styles'
 
-import Icon from '../icon'
+import Arrow from './arrow'
 
 const Carousel = ({
   children,
@@ -27,8 +27,8 @@ const Carousel = ({
   return (
     <div className={classNames.carousel}>
       <Slider
-        nextArrow={<div><Icon name='chevron' /></div>}
-        prevArrow={<div><Icon name='chevron' rotate={180} /></div>}
+        prevArrow={<Arrow direction='prev' />}
+        nextArrow={<Arrow direction='next' />}
         {...allowedProps}>
         {children}
       </Slider>


### PR DESCRIPTION
Removes a long-standing console error present any time a `<Carousel />` component is used:
```
Warning: Unknown props `currentSlide`, `slideCount` on <div> tag. Remove these props from the element.
```

See https://github.com/akiran/react-slick/issues/728 for more information.