### PR TITLE
Update file paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "0.13.13",
+  "version": "0.13.14",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/carousel-arrow/__tests__/CarouselArrow-test.js
+++ b/source/components/carousel-arrow/__tests__/CarouselArrow-test.js
@@ -1,0 +1,12 @@
+import CarouselArrow from '..'
+
+describe('CarouselArrow', () => {
+  it('should render a simple carousel arrow', () => {
+    const wrapper = mount(
+      <CarouselArrow direction='prev' />
+    )
+
+    expect(wrapper.find('button').prop('aria-label')).to.eql('Previous')
+    expect(wrapper.find('svg')).to.have.length(1)
+  })
+})

--- a/source/components/carousel-arrow/index.js
+++ b/source/components/carousel-arrow/index.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Icon from '../../icon'
+import Icon from '../icon'
 
 const labels = {
   prev: 'Previous',
   next: 'Next'
 }
 
-const Arrow = ({
+const CarouselArrow = ({
   currentSlide,
   slideCount,
   direction,
@@ -18,7 +18,7 @@ const Arrow = ({
   </button>
 )
 
-Arrow.propTypes = {
+CarouselArrow.propTypes = {
   /**
   * The direction of the arrow
   */
@@ -28,8 +28,8 @@ Arrow.propTypes = {
   ]).isRequired
 }
 
-Arrow.defaultProps = {
+CarouselArrow.defaultProps = {
   direction: 'next'
 }
 
-export default Arrow
+export default CarouselArrow

--- a/source/components/carousel/__tests__/Carousel-test.js
+++ b/source/components/carousel/__tests__/Carousel-test.js
@@ -1,5 +1,4 @@
 import Carousel from '..'
-import Arrow from '../arrow'
 
 describe('Carousel', () => {
   it('should render a simple carousel', () => {
@@ -23,16 +22,5 @@ describe('Carousel', () => {
 
     expect(wrapper.find('.slick-prev')).to.have.length(1)
     expect(wrapper.find('.slick-next')).to.have.length(1)
-  })
-})
-
-describe('Arrow', () => {
-  it('should render a simple carousel arrow', () => {
-    const wrapper = mount(
-      <Arrow direction='prev' />
-    )
-
-    expect(wrapper.find('button').prop('aria-label')).to.eql('Previous')
-    expect(wrapper.find('svg')).to.have.length(1)
   })
 })

--- a/source/components/carousel/index.js
+++ b/source/components/carousel/index.js
@@ -6,7 +6,7 @@ import compose from '../../lib/compose'
 import { withStyles } from '../../lib/css'
 import styles from './styles'
 
-import Arrow from './arrow'
+import Arrow from '../carousel-arrow'
 
 const Carousel = ({
   children,


### PR DESCRIPTION
Move `<CarouselArrow>` component file location to be exported correctly.

I thought about alternatively updating the script to rename file paths to allow nested components, but in the end I thought it was better to stick with the convention of having every available component at the top level.