### PR TITLE
Reset form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "0.13.15",
+  "version": "0.13.16",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/with-form/Readme.md
+++ b/source/components/with-form/Readme.md
@@ -118,6 +118,18 @@ componentWillReceiveProps (nextProps) {
 
 <br/>
 
+__form.resetForm__
+
+You can call form.resetForm() which will reset all of the form values and validations to their initial state.
+
+```javascript
+handleCancel () {
+  this.props.form.resetForm()
+}
+```
+
+<br/>
+
 __form.submit__
 
 You can call form.submit() which will return a promise that will either:

--- a/source/components/with-form/__tests__/withForm-test.js
+++ b/source/components/with-form/__tests__/withForm-test.js
@@ -121,6 +121,24 @@ describe('withForm', () => {
     expect(changedProps.fields.name.value).to.eql('Jane')
   })
 
+  it ('resets the form via resetForm', () => {
+    const Form = withForm({
+      fields: {
+        name: {
+          label: 'Name',
+          initial: 'Jane'
+        }
+      }
+    })(FormComponent)
+
+    const formEl = getForm(<Form />)
+    const form = formEl.prop('form')
+    form.fields.name.onChange('John')
+    form.resetForm()
+    const updatedForm = formEl.prop('form')
+    expect(updatedForm.fields.name.value).to.eql('Jane')
+  })
+
   it ('will not submit if invalid', (done) => {
     const Form = withForm({
       fields: {

--- a/source/components/with-form/index.js
+++ b/source/components/with-form/index.js
@@ -10,12 +10,14 @@ const withForm = (config) => (ComponentToWrap) => (
       super(props)
       this.handleChange = this.handleChange.bind(this)
       this.updateValues = this.updateValues.bind(this)
+      this.resetForm = this.resetForm.bind(this)
       this.submitForm = this.submitForm.bind(this)
+
       const options = this.initOptions(config)
       const fields = this.initFields(options.fields)
       this.state = {
         fields: this.validateFields(fields),
-        onFormChange: options.onFormChange
+        options
       }
     }
 
@@ -90,8 +92,8 @@ const withForm = (config) => (ComponentToWrap) => (
 
         const fields = this.validateFields(updatedFields)
 
-        if (this.state.onFormChange) {
-          this.state.onFormChange(this.getForm(fields))
+        if (this.state.options.onFormChange) {
+          this.state.options.onFormChange(this.getForm(fields))
         }
 
         this.setState({ fields })
@@ -122,6 +124,13 @@ const withForm = (config) => (ComponentToWrap) => (
       })
     }
 
+    resetForm () {
+      const fields = this.initFields(this.state.options.fields)
+      this.setState({
+        fields: this.validateFields(fields)
+      })
+    }
+
     submitForm () {
       const fields = this.touchFields(this.state.fields)
       this.setState({ fields })
@@ -137,6 +146,7 @@ const withForm = (config) => (ComponentToWrap) => (
         invalid: !this.checkIfValid(fields),
         validations: this.getValidations(fields),
         updateValues: this.updateValues,
+        resetForm: this.resetForm,
         submit: this.submitForm
       }
     }


### PR DESCRIPTION
- Store the whole `options` object in the state, rather than just `onFormChange`
- Update the `onFormChange` use to reflect this above change
- Add `resetForm` function which just re-initialises the form