### PR TITLE
Update `required` validator to account for whitespace in strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/lib/validators/index.js
+++ b/source/lib/validators/index.js
@@ -1,5 +1,12 @@
 export const required = (msg = 'This field is required') => {
-  return (val) => !val && msg
+  return (val) => {
+    switch (typeof val) {
+      case 'string':
+        return !val.trim() && msg
+      default:
+        return !val && msg
+    }
+  }
 }
 
 export const email = (msg = 'A valid email is required') => {


### PR DESCRIPTION
Previously a string containing only spaces passed validation, e.g. `'   '`