### PR TITLE
Move withStyles to be with other higher order components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/accordion/index.js
+++ b/source/components/accordion/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Icon from '../icon'
 import compose from '../../lib/compose'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import withToggle from '../with-toggle'
 import styles from './styles'
 

--- a/source/components/button-group/index.js
+++ b/source/components/button-group/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 const ButtonGroup = ({

--- a/source/components/button/index.js
+++ b/source/components/button/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import omit from 'lodash/omit'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 const Button = ({

--- a/source/components/carousel/index.js
+++ b/source/components/carousel/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import pick from 'lodash/pick'
 import Slider from 'react-slick'
 import compose from '../../lib/compose'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 import Arrow from '../carousel-arrow'

--- a/source/components/container/index.js
+++ b/source/components/container/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 const Container = ({

--- a/source/components/filter/index.js
+++ b/source/components/filter/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Icon from '../icon'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 class Filter extends Component {

--- a/source/components/flippy/index.js
+++ b/source/components/flippy/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 const Flippy = ({

--- a/source/components/form/index.js
+++ b/source/components/form/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 import Button from '../button'

--- a/source/components/grid-column/index.js
+++ b/source/components/grid-column/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 const GridColumn = ({

--- a/source/components/grid/index.js
+++ b/source/components/grid/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 const Grid = ({

--- a/source/components/heading/index.js
+++ b/source/components/heading/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 const Heading = ({

--- a/source/components/icon/index.js
+++ b/source/components/icon/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 import * as icons from './icons'
 

--- a/source/components/input-field/index.js
+++ b/source/components/input-field/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import omit from 'lodash/omit'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 const isBoolean = (type) => {

--- a/source/components/input-select/index.js
+++ b/source/components/input-select/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import omit from 'lodash/omit'
 import mapKeys from 'lodash/mapKeys'
 import groupBy from 'lodash/groupBy'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 import Icon from '../icon'

--- a/source/components/leaderboard-item/index.js
+++ b/source/components/leaderboard-item/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 const LeaderboardItem = ({

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import isEmpty from 'lodash/isEmpty'
 import Icon from '../icon'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 class Leaderboard extends Component {

--- a/source/components/metric-group/index.js
+++ b/source/components/metric-group/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 const MetricGroup = ({

--- a/source/components/metric/index.js
+++ b/source/components/metric/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Icon from '../icon'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 const Metric = ({

--- a/source/components/modal/index.js
+++ b/source/components/modal/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import ReactModal from 'react-modal'
 import Icon from '../icon'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 /**

--- a/source/components/progress-bar/index.js
+++ b/source/components/progress-bar/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 import template from 'lodash/template'
 

--- a/source/components/rich-text/index.js
+++ b/source/components/rich-text/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 const RichText = ({

--- a/source/components/search-form/index.js
+++ b/source/components/search-form/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Button from '../button'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import withToggle from '../with-toggle'
 import compose from '../../lib/compose'
 import styles from './styles'

--- a/source/components/search-result/index.js
+++ b/source/components/search-result/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 import Button from '../button'
 

--- a/source/components/search-results/index.js
+++ b/source/components/search-results/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import isEmpty from 'lodash/isEmpty'
 import Icon from '../icon'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 class SearchResults extends Component {

--- a/source/components/section/index.js
+++ b/source/components/section/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { withStyles } from '../../lib/css'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 const Section = ({

--- a/source/components/with-styles/Readme.md
+++ b/source/components/with-styles/Readme.md
@@ -1,0 +1,46 @@
+__withStyles__ is a higher order component (HOC) that allows you to style your components.
+
+It works by taking your styles as an argument, and then passing in a couple of useful props to your component.
+
+# Usage
+
+The styles function you pass as an argument to __withStyles__, will receive two arguments.
+
+**props** - the props for the styled component so you can apply conditional styles
+
+**traits** - your style traits, which include any themed traits that have been setup by `TraitsProvider`
+
+Your styles function should return an object, where each key within the object will be processed as it's own set of styles.
+
+__withStyles__ will inject 2 props into our component that we can use
+
+**classNames** - these are class strings that you can attach directly to HTML elements e.g. if your styles function returns an object with keys `title` and `body`, your classNames prop will also be an object with keys `title` and `body`
+
+**styles** - these are the style defintions that can be forwarded onto other React components to be processed, such as for customising styles of Constructicon components. As above, the styles prop will have the same keys as the object returned from your styles function.
+
+### Example
+
+```javascript
+const MyComponent = ({
+  classNames,
+  copy,
+  styles,
+  title
+}) => (
+  <div>
+    <Heading styles={styles.heading}>{title}</Heading>
+    <div className={classNames.body}>{copy}</div>
+  </div>
+)
+
+const styles = (props, traits) => ({
+  heading: {
+    fontSize: traits.scale(4)
+  },
+  body: {
+    padding: traits.rhythm(1)
+  }
+})
+
+export default withStyles(styles)(MyComponent)
+```

--- a/source/components/with-styles/__tests__/index.js
+++ b/source/components/with-styles/__tests__/index.js
@@ -1,0 +1,23 @@
+import withStyles from '..'
+
+describe('withStyles', () => {
+  const Component = (props) => <div />
+
+  const styles = (props, traits) => ({
+    title: {
+      fontSize: '3rem'
+    }
+  })
+
+  it ('provides a classNames prop as an object with generated class names', () => {
+    const StyledComponent = withStyles(styles)(Component)
+    const props = mount(<StyledComponent />).find('Component').props()
+    expect(props.classNames.title).to.contain('cxsync-')
+  })
+
+  it ('provides a styles prop as an object with related style objects', () => {
+    const StyledComponent = withStyles(styles)(Component)
+    const props = mount(<StyledComponent />).find('Component').props()
+    expect(props.styles.title.fontSize).to.contain('3rem')
+  })
+})

--- a/source/components/with-styles/index.js
+++ b/source/components/with-styles/index.js
@@ -1,0 +1,62 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import cxs from 'cxsync'
+import * as defaultTraits from '../../lib/traits'
+
+export const css = cxs
+
+/**
+* Turns a styles object into an object containing the cxs class name for each key
+*/
+export const stylesToClasses = (styles = {}) => (
+  Object.keys(styles).reduce((acc, key) => ({
+    ...acc,
+    [key]: css(styles[key])
+  }), {})
+)
+
+/**
+* Higher order component to take a styles function and call it with the necessary props and traits
+*/
+const withStyles = (styles) => (ComponentToWrap) => {
+  class ConnectStyles extends Component {
+    render () {
+      // get current traits and defaults from context
+      const {
+        traits = defaultTraits
+      } = this.context
+
+      // build our combined props from the component itself's default props,
+      // the specified default traits, and the actual provided props
+      const combinedProps = {
+        ...ComponentToWrap.defaultProps,
+        ...this.props
+      }
+
+      // if styles is a function, call it and pass through our props and traits
+      const stylesIsFunction = typeof styles === 'function'
+      const stylesObj = stylesIsFunction ? styles(combinedProps, traits) : styles
+
+      // build out our final props to be passed down to the original component
+      const newProps = {
+        ...combinedProps,
+        styles: stylesObj,
+        classNames: stylesToClasses(stylesObj)
+      }
+
+      return (
+        <ComponentToWrap
+          {...newProps}
+        />
+      )
+    }
+  }
+
+  ConnectStyles.contextTypes = {
+    traits: PropTypes.object
+  }
+
+  return ConnectStyles
+}
+
+export default withStyles

--- a/source/lib/css/index.js
+++ b/source/lib/css/index.js
@@ -1,60 +1,9 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import cxs from 'cxsync'
-import * as defaultTraits from '../traits'
+import css from 'cxsync'
+import rawWithStyles, { stylesToClasses } from '../../components/with-styles'
 
-export const css = cxs
+export { css, stylesToClasses }
 
-/**
-* Turns a styles object into an object containing the cxs class name for each key
-*/
-export const stylesToClasses = (styles = {}) => (
-  Object.keys(styles).reduce((acc, key) => ({
-    ...acc,
-    [key]: css(styles[key])
-  }), {})
-)
-
-/**
-* Higher order component to take a styles function and call it with the necessary props and traits
-*/
-export const withStyles = (styles) => (ComponentToWrap) => {
-  class ConnectStyles extends Component {
-    render () {
-      // get current traits and defaults from context
-      const {
-        traits = defaultTraits
-      } = this.context
-
-      // build our combined props from the component itself's default props,
-      // the specified default traits, and the actual provided props
-      const combinedProps = {
-        ...ComponentToWrap.defaultProps,
-        ...this.props
-      }
-
-      // if styles is a function, call it and pass through our props and traits
-      const stylesIsFunction = typeof styles === 'function'
-      const stylesObj = stylesIsFunction ? styles(combinedProps, traits) : styles
-
-      // build out our final props to be passed down to the original component
-      const newProps = {
-        ...combinedProps,
-        styles: stylesObj,
-        classNames: stylesToClasses(stylesObj)
-      }
-
-      return (
-        <ComponentToWrap
-          {...newProps}
-        />
-      )
-    }
-  }
-
-  ConnectStyles.contextTypes = {
-    traits: PropTypes.object
-  }
-
-  return ConnectStyles
+export const withStyles = (styles) => {
+  console.log('Development warning: withStyles should now be imported the same way as other higher order components i.e. import withStyles from `construction/with-styles`. Support for importing from `constructicon/lib/css` will be removed in version 2')
+  return rawWithStyles(styles)
 }


### PR DESCRIPTION
For consistency and just because it makes more sense, now instead of...

`import { withStyles } from 'constructicon/lib/css'`

it will be...

`import withStyles from 'constructicon/with-styles`

Changes include:

- Moving `withStyles` to components directory
- Adding quick docs and tests
- It is still exposed via `lib/css` for the time being for backwards compatability
- However, if imported via the old way, it will display a deprecation warning