### PR TITLE
Typeahead

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "prop-types": "^15.5.8",
     "react-helmet": "^5.1.3",
     "react-modal": "^1.9.4",
+    "react-onclickoutside": "^6.7.1",
     "react-slick": "0.14.11"
   },
   "devDependencies": {

--- a/source/components/input-search/__tests__/InputSearch-test.js
+++ b/source/components/input-search/__tests__/InputSearch-test.js
@@ -1,0 +1,90 @@
+import InputSearch from '..'
+
+describe('InputSearch', () => {
+  it('fires the onSearch callback when values are user searches', () => {
+    const onSearch = sinon.spy()
+    const wrapper = mount(
+      <InputSearch
+        onSearch={onSearch}
+        ResultComponent={() => <div>Result</div>}
+      />
+    )
+
+    const filter = wrapper.find('Filter')
+    const onChange = filter.prop('onChange')
+    onChange('test')
+
+    expect(onSearch.callCount).to.eql(1)
+    expect(onSearch.firstCall.args[0]).to.eql('test')
+  })
+
+  it('hides results if search is empty', () => {
+    const Result = () => <div>Result</div>
+    const wrapper = mount(
+      <InputSearch
+        onSearch={() => {}}
+        ResultComponent={Result}
+        results={[ 'one', 'two', 'three' ]}
+      />
+    )
+
+    const results = wrapper.find('Result')
+    expect(results.length).to.eql(0)
+  })
+
+  it('renders results when search is active', () => {
+    const Result = () => <div>Result</div>
+    const wrapper = mount(
+      <InputSearch
+        onSearch={() => {}}
+        ResultComponent={Result}
+        results={[ 'one', 'two', 'three' ]}
+      />
+    )
+
+    const filter = wrapper.find('Filter')
+    const onChange = filter.prop('onChange')
+    onChange('foo')
+
+    const results = wrapper.find('Result')
+    expect(results.length).to.eql(3)
+  })
+
+  it('renders loading spinner if status is fetching', () => {
+    const Result = () => <div>Result</div>
+    const wrapper = mount(
+      <InputSearch
+        onSearch={() => {}}
+        ResultComponent={Result}
+        results={[ 'one', 'two', 'three' ]}
+        status='fetching'
+      />
+    )
+
+    const filter = wrapper.find('Filter')
+    const onChange = filter.prop('onChange')
+    onChange('foo')
+
+    const icon = wrapper.find('Icon').last()
+    expect(icon.prop('name')).to.eql('loading')
+  })
+
+  it('renders warning if status is failed', () => {
+    const Result = () => <div>Result</div>
+    const wrapper = mount(
+      <InputSearch
+        onSearch={() => {}}
+        ResultComponent={Result}
+        results={[ 'one', 'two', 'three' ]}
+        status='failed'
+      />
+    )
+
+    const filter = wrapper.find('Filter')
+    const onChange = filter.prop('onChange')
+    onChange('foo')
+
+    const icon = wrapper.find('Icon').last()
+    expect(icon.prop('name')).to.eql('warning')
+  })
+})

--- a/source/components/input-search/index.js
+++ b/source/components/input-search/index.js
@@ -24,21 +24,31 @@ class InputSearch extends Component {
   }
 
   handleChange (query) {
-    this.scrollToTop(this.refs.results)
+    if (this.refs.results) this.refs.results.scrollTop = 0
     this.setState({ query }, this.sendQuery)
   }
 
   handleKeyDown (e) {
     switch (e.key) {
       case 'ArrowUp':
+        e.preventDefault()
         return this.setSelectedItem(this.state.selected - 1)
       case 'ArrowDown':
+        e.preventDefault()
         return this.setSelectedItem(this.state.selected + 1)
       case 'Enter':
+        e.preventDefault()
         return this.confirmSelection()
       case 'Escape':
-      case 'Backspace':
+        e.preventDefault()
         return this.clearSelection()
+      case 'Backspace':
+        if (this.state.selected !== -1) {
+          e.preventDefault()
+          return this.clearSelection()
+        } else {
+          return null
+        }
       default:
         return null
     }
@@ -46,10 +56,6 @@ class InputSearch extends Component {
 
   handleClickOutside () {
     this.clearSelection()
-  }
-
-  scrollToTop (ref = {}) {
-    ref.scrollTop = 0
   }
 
   sendQuery (query) {

--- a/source/components/input-search/index.js
+++ b/source/components/input-search/index.js
@@ -1,0 +1,238 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import isEmpty from 'lodash/isEmpty'
+import withStyles from '../with-styles'
+import styles from './styles'
+
+import Filter from '../filter'
+import Icon from '../icon'
+
+class InputSearch extends Component {
+  constructor (props) {
+    super(props)
+    this.handleChange = this.handleChange.bind(this)
+    this.handleKeyDown = this.handleKeyDown.bind(this)
+    this.showMore = this.showMore.bind(this)
+
+    this.state = {
+      query: '',
+      selected: -1,
+      toShow: props.limit
+    }
+  }
+
+  handleChange (query) {
+    this.scrollToTop(this.refs.results)
+    this.setState({ query }, this.sendQuery)
+  }
+
+  handleKeyDown (e) {
+    switch (e.key) {
+      case 'ArrowUp':
+        return this.setSelectedItem(this.state.selected - 1)
+      case 'ArrowDown':
+        return this.setSelectedItem(this.state.selected + 1)
+      case 'Enter':
+        return this.confirmSelection()
+      case 'Escape':
+      case 'Backspace':
+        return this.clearSelection()
+      default:
+        return null
+    }
+  }
+
+  scrollToTop (ref = {}) {
+    ref.scrollTop = 0
+  }
+
+  sendQuery (query) {
+    this.props.onSearch(this.state.query)
+  }
+
+  setSelectedItem (selected) {
+    const { results } = this.props
+
+    if (results.length) {
+      const newSelectedIndex = selected < 0
+        ? results.length - 1
+        : selected >= results.length
+          ? 0
+          : selected
+
+      this.setState({
+        selected: newSelectedIndex
+      })
+    }
+  }
+
+  confirmSelection () {
+    const { selected } = this.state
+    const { onSelect, results } = this.props
+    const selectedResult = results[selected]
+    onSelect(selectedResult)
+  }
+
+  clearSelection () {
+    this.setState({
+      query: '',
+      selected: -1,
+      toShow: this.props.limit
+    })
+  }
+
+  showMore () {
+    const { toShow } = this.state
+    const { limit } = this.props
+    this.setState({
+      toShow: toShow + limit
+    })
+  }
+
+  render () {
+    const {
+      classNames,
+      filter
+    } = this.props
+
+    const {
+      query
+    } = this.state
+
+    return (
+      <div className={classNames.root} onKeyDown={this.handleKeyDown}>
+        <Filter onChange={this.handleChange} {...filter} />
+        {query && (
+          <div className={classNames.results} ref='results'>
+            {this.renderResults()}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  renderResults () {
+    const { toShow } = this.state
+
+    const {
+      classNames,
+      emptyMessage,
+      errorMessage,
+      ResultComponent,
+      results,
+      showMore,
+      status
+    } = this.props
+
+    if (status === 'fetching') {
+      return (
+        <div className={classNames.status}>
+          <Icon name='loading' spin />
+        </div>
+      )
+    }
+
+    if (status === 'failed') {
+      return (
+        <div className={classNames.status}>
+          <Icon name='warning' /> {errorMessage}
+        </div>
+      )
+    }
+
+    if (isEmpty(results)) {
+      return (
+        <div className={classNames.status}>
+          <Icon name='warning' /> {emptyMessage}
+        </div>
+      )
+    }
+
+    return (
+      <div>
+        {results.slice(0, toShow).map((result, index) => (
+          <ResultComponent {...result}
+            key={index}
+            isSelected={index === this.state.selected}
+          />
+        ))}
+        {showMore && this.renderShowMore()}
+      </div>
+    )
+  }
+
+  renderShowMore () {
+    const { classNames, results = [] } = this.props
+    const { toShow } = this.state
+
+    return results.length > toShow && (
+      <div
+        className={classNames.showMore}
+        onClick={this.showMore}>
+        Load More <Icon name='chevron' size={0.75} rotate={90} />
+      </div>
+    )
+  }
+}
+
+InputSearch.propTypes = {
+  /**
+  * The message to display when no results are found
+  */
+  emptyMessage: PropTypes.string,
+
+  /**
+  * The message to display when there is an error
+  */
+  errorMessage: PropTypes.string,
+
+  /**
+  * The props to be passed onto the Filter component
+  */
+  filter: PropTypes.object,
+
+  /**
+  * The number of results to show
+  */
+  limit: PropTypes.number,
+
+  /**
+  * The function to call when the search is altered
+  */
+  onSearch: PropTypes.func.isRequired,
+
+  /**
+  * The function to call when a user selects an item
+  */
+  onSelect: PropTypes.func,
+
+  /**
+  * A component that is used to render each individual result
+  */
+  ResultComponent: PropTypes.func.isRequired,
+
+  /**
+  * The array of currently applicable results
+  */
+  results: PropTypes.array,
+
+  /**
+  * Enables a Show More button
+  */
+  showMore: PropTypes.bool,
+
+  /**
+  * The status of the searching
+  */
+  status: PropTypes.oneOf([ 'fetching', 'fetched', 'failed' ])
+}
+
+InputSearch.defaultProps = {
+  emptyMessage: 'No results found',
+  errorMessage: 'There was an unexpected error',
+  limit: 5,
+  onSelect: () => {},
+  results: []
+}
+
+export default withStyles(styles)(InputSearch)

--- a/source/components/input-search/index.js
+++ b/source/components/input-search/index.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import compose from '../../lib/compose'
+import onClickOutside from 'react-onclickoutside'
 import isEmpty from 'lodash/isEmpty'
 import withStyles from '../with-styles'
 import styles from './styles'
@@ -40,6 +42,10 @@ class InputSearch extends Component {
       default:
         return null
     }
+  }
+
+  handleClickOutside () {
+    this.clearSelection()
   }
 
   scrollToTop (ref = {}) {
@@ -235,4 +241,7 @@ InputSearch.defaultProps = {
   results: []
 }
 
-export default withStyles(styles)(InputSearch)
+export default compose(
+  withStyles(styles),
+  onClickOutside
+)(InputSearch)

--- a/source/components/input-search/readme.md
+++ b/source/components/input-search/readme.md
@@ -1,0 +1,29 @@
+# Examples
+
+**Standard Use**
+
+```
+const data = [
+  { name: 'joe' },
+  { name: 'john' },
+  { name: 'jane' },
+  { name: 'janet' }
+];
+
+initialState = {
+  results: []
+};
+
+const Result = (props) => (
+  <div style={{ padding: '1rem', background: props.isSelected && 'red' }}>
+    {props.name}
+  </div>
+);
+
+<InputSearch
+  onSearch={(v) => setState({ results: data.filter((r) => r.name.indexOf(v) !== -1) })}
+  onSelect={(r) => window.alert(r.name)}
+  ResultComponent={Result}
+  results={state.results}
+/>
+```

--- a/source/components/input-search/styles.js
+++ b/source/components/input-search/styles.js
@@ -1,0 +1,51 @@
+import merge from 'lodash/merge'
+
+export default ({
+  styles
+}, {
+  colors,
+  rhythm,
+  scale,
+  shadows
+}) => {
+  const baseStyles = {
+    root: {
+      position: 'relative'
+    },
+
+    results: {
+      position: 'absolute',
+      zIndex: 6,
+      maxHeight: rhythm(12),
+      overflow: 'auto',
+      top: '100%',
+      left: 0,
+      right: 0,
+      backgroundColor: colors.light,
+      color: colors.dark,
+      boxShadow: shadows.light
+    },
+
+    status: {
+      padding: rhythm(1),
+      textAlign: 'center',
+      fontSize: scale(-1),
+      opacity: 0.5
+    },
+
+    showMore: {
+      padding: rhythm(0.5),
+      textAlign: 'center',
+      fontSize: scale(-1),
+      fontWeight: 500,
+      cursor: 'pointer',
+
+      ':hover': {
+        backgroundColor: colors.primary,
+        color: colors.light
+      }
+    }
+  }
+
+  return merge(baseStyles, styles)
+}

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -38,6 +38,7 @@ module.exports = {
         path.resolve(__dirname, 'source/components/form', 'index.js'),
         path.resolve(__dirname, 'source/components/input-field', 'index.js'),
         path.resolve(__dirname, 'source/components/input-select', 'index.js'),
+        path.resolve(__dirname, 'source/components/input-search', 'index.js'),
         path.resolve(__dirname, 'source/components/search-form', 'index.js')
       ])
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4934,6 +4934,10 @@ react-modal@^1.9.4:
     lodash.assign "^4.2.0"
     prop-types "^15.5.7"
 
+react-onclickoutside@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
+
 react-prefixer@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/react-prefixer/-/react-prefixer-1.1.4.tgz#e32a01c8c0dbb0f918ccd428a94932a943abf24b"


### PR DESCRIPTION
- closes when clicked outside
- keyboard navigation
- customise empty or error messages
- loading, error, empty and valid states
- limit the number of results to show at a time
- enable a Show More button which loads in more results when clicked
- onSearch(val) callback to fetch/filter data when the user types
- onSelect(result) callback if the user hits `Enter` on a result
- pass in a `ResultComponent`, which is used to render each result

![typeahead](https://user-images.githubusercontent.com/1445686/36013417-b6b0b118-0daf-11e8-8657-c3513a9fe92d.gif)
