### PR TITLE
Add InputDate component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "cxsync": "^1.0.9",
     "lodash": "^4.17.4",
     "minimal.css": "^1.0.1",
+    "moment": "^2.19.1",
     "prop-types": "^15.5.8",
     "react-helmet": "^5.1.3",
     "react-modal": "^1.9.4",

--- a/source/components/input-date/Readme.md
+++ b/source/components/input-date/Readme.md
@@ -6,6 +6,7 @@ Pass an onChange callback to be notified of changes
 
 ```
 initialState = { date: '' };
+styles = { padding: '1rem', textAlign: 'center', backgroundColor: 'whitesmoke' };
 
 <div>
   <InputDate
@@ -15,6 +16,9 @@ initialState = { date: '' };
     onChange={(v) => setState({ date: v })}
     required
   />
+  <div style={styles}>
+    {state.date || 'No date selected'}
+  </div>
 </div>
 ```
 
@@ -22,6 +26,7 @@ initialState = { date: '' };
 
 ```
 initialState = { date: '' };
+styles = { padding: '1rem', textAlign: 'center', backgroundColor: 'whitesmoke' };
 
 <div>
   <InputDate
@@ -31,5 +36,8 @@ initialState = { date: '' };
     onChange={(v) => setState({ date: v })}
     showSelects
   />
+  <div style={styles}>
+    {state.date || 'No date selected'}
+  </div>
 </div>
 ```

--- a/source/components/input-date/Readme.md
+++ b/source/components/input-date/Readme.md
@@ -1,0 +1,35 @@
+# Examples
+
+**Standard Use**
+
+Pass an onChange callback to be notified of changes
+
+```
+initialState = { date: '' };
+
+<div>
+  <InputDate
+    label='Date of Birth'
+    name='birthday'
+    value={state.date}
+    onChange={(v) => setState({ date: v })}
+    required
+  />
+</div>
+```
+
+**Always show selects**
+
+```
+initialState = { date: '' };
+
+<div>
+  <InputDate
+    label='Date of Birth'
+    name='birthday'
+    value={state.date}
+    onChange={(v) => setState({ date: v })}
+    showSelects
+  />
+</div>
+```

--- a/source/components/input-date/__tests__/InputDate-test.js
+++ b/source/components/input-date/__tests__/InputDate-test.js
@@ -14,5 +14,84 @@ describe('InputDate', () => {
     expect(label.length).to.eql(1)
   })
 
-  // TODO: Write more tests!
+  it('should set the placeholder', () => {
+    const wrapper = mount(
+      <InputDate
+        label='Test Field'
+        name='test-name'
+        onChange={() => {}}
+        placeholder='My test placeholder'
+      />
+    )
+    const input = wrapper.find('input')
+    expect(input.prop('placeholder')).to.eql('My test placeholder')
+  })
+
+  it('should fire the onChange handler', (done) => {
+    let called
+    const wrapper = mount(
+      <InputDate
+        label='Test Field'
+        name='test-name'
+        onChange={() => called = true}
+      />
+    )
+    const input = wrapper.find('input')
+    input.simulate('change', { target: { value: 'test' } })
+
+    // need to wait for callback to debounce
+    setTimeout(() => {
+      expect(called).to.eql(true)
+      done()
+    }, 500)
+  })
+
+  it('should render selects', () => {
+    const wrapper = mount(
+      <InputDate
+        label='Test Field'
+        name='test-name'
+        onChange={() => {}}
+        showSelects
+      />
+    )
+
+    expect(wrapper.find('select')).to.have.length(3)
+  })
+
+  it('should set the set custom attributes on the input', () => {
+    const wrapper = mount(
+      <InputDate
+        label='Test Field'
+        name='test-name'
+        onChange={() => {}}
+        showSelects
+        disabled
+      />
+    )
+
+    expect(wrapper.find('select').at(0).prop('disabled')).to.eql(true)
+  })
+
+  it('should handle dates correctly', (done) => {
+    let dateValue = '2018-12-31'
+
+    const wrapper = mount(
+      <InputDate
+        label='Test Field'
+        name='test-name'
+        value={dateValue}
+        showSelects
+        onChange={(value) => dateValue = value}
+      />
+    )
+    const input = wrapper.find('select').at(1)
+    input.simulate('change', { target: { value: 1 } })
+
+    // need to wait for callback to debounce
+    setTimeout(() => {
+      expect(dateValue).to.eql('2018-02-28')
+      done()
+    }, 500)
+  })
 })

--- a/source/components/input-date/__tests__/InputDate-test.js
+++ b/source/components/input-date/__tests__/InputDate-test.js
@@ -1,0 +1,18 @@
+import InputDate from '..'
+
+describe('InputDate', () => {
+  it('should render a simple input field', () => {
+    const wrapper = mount(
+      <InputDate
+        label='Test Field'
+        name='test-name'
+        onChange={() => {}}
+      />
+    )
+
+    const label = wrapper.find('label')
+    expect(label.length).to.eql(1)
+  })
+
+  // TODO: Write more tests!
+})

--- a/source/components/input-date/index.js
+++ b/source/components/input-date/index.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react'
 import moment from 'moment'
 import range from 'lodash/range'
-import { withStyles } from '../../lib/css'
+import pick from 'lodash/pick'
+import withStyles from '../with-styles'
 import styles from './styles'
 
 import InputField from '../input-field'
@@ -69,6 +70,7 @@ class InputDate extends Component {
       date = moment()
     } = this.state
 
+    const allowedProps = pick(this.props, ['disabled', 'placeholder', 'required'])
     const months = [{ label: 'January', value: 0 }, { label: 'February', value: 1 }, { label: 'March', value: 2 }, { label: 'April', value: 3 }, { label: 'May', value: 4 }, { label: 'June', value: 5 }, { label: 'July', value: 6 }, { label: 'August', value: 7 }, { label: 'September', value: 8 }, { label: 'October', value: 9 }, { label: 'November', value: 10 }, { label: 'December', value: 11 }]
     const daysInMonth = date.daysInMonth() || 31
 
@@ -81,9 +83,36 @@ class InputDate extends Component {
           {required && <span className={classNames.required}>*</span>}
         </label>
         <div className={classNames.wrapper}>
-          <InputSelect styles={styles.input} value={date.date().toString()} onChange={this.updateDay} label='Day' name={`${name}-day`} options={mapValues(range(1, daysInMonth + 1))} />
-          <InputSelect styles={styles.input} value={date.month().toString()} onChange={this.updateMonth} label='Month' name={`${name}-month`} options={months} />
-          <InputSelect styles={styles.input} value={date.year().toString()} onChange={this.updateYear} label='Year' name={`${name}-year`} options={mapValues(range(1900, parseInt(moment().year() + 1)))} />
+          <InputSelect
+            {...allowedProps}
+            styles={styles.input}
+            value={date.date().toString()}
+            onChange={this.updateDay}
+            onBlur={this.updateDay}
+            label='Day'
+            name={`${name}-day`}
+            options={mapValues(range(1, daysInMonth + 1))}
+          />
+          <InputSelect
+            {...allowedProps}
+            styles={styles.input}
+            value={date.month().toString()}
+            onChange={this.updateMonth}
+            onBlur={this.updateMonth}
+            label='Month'
+            name={`${name}-month`}
+            options={months}
+          />
+          <InputSelect
+            {...allowedProps}
+            styles={styles.input}
+            value={date.year().toString()}
+            onChange={this.updateYear}
+            onBlur={this.updateYear}
+            label='Year'
+            name={`${name}-year`}
+            options={mapValues(range(1900, parseInt(moment().year() + 1)))}
+          />
         </div>
         {error && (
           <div className={classNames.errors}>

--- a/source/components/input-date/index.js
+++ b/source/components/input-date/index.js
@@ -1,0 +1,102 @@
+import React, { Component } from 'react'
+import moment from 'moment'
+import range from 'lodash/range'
+import { withStyles } from '../../lib/css'
+import styles from './styles'
+
+import InputField from '../input-field'
+import InputSelect from '../input-select'
+
+class InputDate extends Component {
+  constructor (props) {
+    super(props)
+    this.updateDay = this.updateDay.bind(this)
+    this.updateMonth = this.updateMonth.bind(this)
+    this.updateYear = this.updateYear.bind(this)
+    this.updateDate = this.updateDate.bind(this)
+
+    this.state = {
+      showSelects: props.showSelects,
+      value: props.value,
+      date: props.value ? moment(props.value) : moment()
+    }
+  }
+
+  testDateInput () {
+    const test = document.createElement('input')
+    test.type = 'date'
+    return test.type === 'text'
+  }
+
+  componentDidMount () {
+    if (this.testDateInput()) this.setState({ showSelects: true })
+  }
+
+  updateDay (day) {
+    const date = this.state.date.date(day)
+    this.updateDate(date)
+  }
+
+  updateMonth (month) {
+    const date = this.state.date.month(month)
+    this.updateDate(date)
+  }
+
+  updateYear (year) {
+    const date = this.state.date.year(year)
+    this.updateDate(date)
+  }
+
+  updateDate (moment) {
+    this.setState({ date: moment })
+    this.props.onChange(moment.format('YYYY-MM-DD'))
+  }
+
+  render () {
+    const {
+      required = false,
+      id,
+      label,
+      name,
+      error,
+      validations,
+      classNames,
+      styles
+    } = this.props
+
+    const {
+      showSelects,
+      date = moment()
+    } = this.state
+
+    const months = [{ label: 'January', value: 0 }, { label: 'February', value: 1 }, { label: 'March', value: 2 }, { label: 'April', value: 3 }, { label: 'May', value: 4 }, { label: 'June', value: 5 }, { label: 'July', value: 6 }, { label: 'August', value: 7 }, { label: 'September', value: 8 }, { label: 'October', value: 9 }, { label: 'November', value: 10 }, { label: 'December', value: 11 }]
+    const daysInMonth = date.daysInMonth() || 31
+
+    const mapValues = (array) => array.map((value) => ({ label: value, value: value }))
+
+    return showSelects ? (
+      <div className={classNames.root} id={id}>
+        <label className={classNames.label}>
+          {label}
+          {required && <span className={classNames.required}>*</span>}
+        </label>
+        <div className={classNames.wrapper}>
+          <InputSelect styles={styles.input} value={date.date().toString()} onChange={this.updateDay} label='Day' name={`${name}-day`} options={mapValues(range(1, daysInMonth + 1))} />
+          <InputSelect styles={styles.input} value={date.month().toString()} onChange={this.updateMonth} label='Month' name={`${name}-month`} options={months} />
+          <InputSelect styles={styles.input} value={date.year().toString()} onChange={this.updateYear} label='Year' name={`${name}-year`} options={mapValues(range(1900, parseInt(moment().year() + 1)))} />
+        </div>
+        {error && (
+          <div className={classNames.errors}>
+            {validations.map((error, i) => (
+              <div className={classNames.error} key={i}>
+                {error}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    ) : <InputField type='date' {...this.props} />
+  }
+}
+
+export default withStyles(styles)(InputDate)

--- a/source/components/input-date/styles.js
+++ b/source/components/input-date/styles.js
@@ -1,0 +1,72 @@
+import merge from 'lodash/merge'
+
+export default (props, traits) => {
+  const {
+    colors,
+    fonts,
+    measures,
+    radiuses,
+    rhythm,
+    scale
+  } = traits
+
+  const {
+    type,
+    spacing = 0.5
+  } = props
+
+  const invalid = props.touched && props.invalid
+
+  const baseStyles = {
+    root: {
+      display: 'block',
+      position: 'relative',
+      fontFamily: fonts.body,
+      textAlign: 'left',
+      marginBottom: rhythm(1)
+    },
+
+    label: {
+      display: 'block',
+      fontWeight: 700,
+      fontSize: scale(-0.5),
+      lineHeight: measures.medium,
+      textAlign: 'left',
+      marginBottom: rhythm(0.25),
+      'a': {
+        color: colors.primary,
+        textDecoration: 'underline'
+      }
+    },
+
+    required: {
+      display: 'inline-block',
+      color: colors.danger
+    },
+
+    error: {
+      fontSize: scale(-0.75),
+      fontWeight: 700,
+      marginTop: rhythm(0.5),
+      color: colors.danger
+    },
+
+    wrapper: {
+      display: 'flex',
+      flexWrap: 'nowrap',
+      marginLeft: rhythm(-spacing)
+    },
+
+    input: {
+      root: {
+        marginBottom: 0,
+        marginLeft: rhythm(spacing)
+      },
+      label: {
+        display: 'none'
+      }
+    }
+  }
+
+  return merge(baseStyles, props.styles)
+}

--- a/source/components/input-date/styles.js
+++ b/source/components/input-date/styles.js
@@ -1,22 +1,15 @@
 import merge from 'lodash/merge'
 
-export default (props, traits) => {
-  const {
-    colors,
-    fonts,
-    measures,
-    radiuses,
-    rhythm,
-    scale
-  } = traits
-
-  const {
-    type,
-    spacing = 0.5
-  } = props
-
-  const invalid = props.touched && props.invalid
-
+export default ({
+  spacing = 0.5,
+  styles
+}, {
+  rhythm,
+  scale,
+  colors,
+  fonts,
+  measures
+}) => {
   const baseStyles = {
     root: {
       display: 'block',
@@ -59,8 +52,12 @@ export default (props, traits) => {
 
     input: {
       root: {
+        flex: 'auto',
         marginBottom: 0,
         marginLeft: rhythm(spacing)
+      },
+      field: {
+        textAlign: 'center'
       },
       label: {
         display: 'none'
@@ -68,5 +65,5 @@ export default (props, traits) => {
     }
   }
 
-  return merge(baseStyles, props.styles)
+  return merge(baseStyles, styles)
 }

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -38,6 +38,7 @@ module.exports = {
         path.resolve(__dirname, 'source/components/form', 'index.js'),
         path.resolve(__dirname, 'source/components/input-field', 'index.js'),
         path.resolve(__dirname, 'source/components/input-select', 'index.js'),
+        path.resolve(__dirname, 'source/components/input-date', 'index.js'),
         path.resolve(__dirname, 'source/components/search-form', 'index.js')
       ])
     },

--- a/styleguide.template.html
+++ b/styleguide.template.html
@@ -6,12 +6,9 @@
 		<title><%=htmlWebpackPlugin.options.title%></title>
 	</head>
 	<body>
+
     <div class="ReactStyleguidist-StyleGuide__content ReactStyleguidist-common__font">
-      <h1 class="page_heading ReactStyleguidist-Section__heading">
-        Constructicon
-        <a href="https://www.npmjs.com/package/constructicon"><img src="https://img.shields.io/npm/v/constructicon.svg?style=flat-square&colorB=43aa4c" alt="npm version"></a>
-        <a href="https://github.com/everydayhero/constructicon"><img src="https://badge.buildkite.com/670ae004c2a2a3b10f5d875b5093edcb90c18c6a1e7855939e.svg" alt="build status" /></a>
-      </h1>
+      <h1 class="page_heading ReactStyleguidist-Section__heading">Constructicon <a href="https://www.npmjs.com/package/constructicon"><img src="https://img.shields.io/npm/v/constructicon.svg?style=flat-square&colorB=43aa4c" alt="npm version"></a></h1>
       <p class='large'>A collection of common patterns used across many Professional Services projects.</p>
       <p>The aim of this library is to provide a toolbelt of components, that will allow us to compose sites together more quickly and consistently.</p>
       <a class='button' href="https://github.com/everydayhero/constructicon">View Project on Github</a>

--- a/styleguide.template.html
+++ b/styleguide.template.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
-	<head>
-		<meta charset="utf-8">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width" />
     <link rel="shortcut icon" href="https://d8i1a0qhidbs8.cloudfront.net/image/favicon.png" type="image/vnd.microsoft.icon">
-		<title><%=htmlWebpackPlugin.options.title%></title>
-	</head>
-	<body>
-
+    <title><%=htmlWebpackPlugin.options.title%></title>
+  </head>
+  <body>
     <div class="ReactStyleguidist-StyleGuide__content ReactStyleguidist-common__font">
       <h1 class="page_heading ReactStyleguidist-Section__heading">Constructicon <a href="https://www.npmjs.com/package/constructicon"><img src="https://img.shields.io/npm/v/constructicon.svg?style=flat-square&colorB=43aa4c" alt="npm version"></a></h1>
       <p class='large'>A collection of common patterns used across many Professional Services projects.</p>
@@ -29,11 +29,6 @@
         font-family: "proxima-nova", sans-serif;
       }
 
-      .ReactStyleguidist-StyleGuide__content {
-        max-width: 50rem;
-        padding: 2rem;
-      }
-
       .ReactStyleguidist-Markdown__ul .ReactStyleguidist-Markdown__code,
       .ReactStyleguidist-Markdown__ol .ReactStyleguidist-Markdown__code,
       .ReactStyleguidist-Markdown__p .ReactStyleguidist-Markdown__code {
@@ -49,12 +44,6 @@
       .ReactStyleguidist-Markdown__ul li {
         margin-top: 0.5rem;
         margin-bottom: 0.5rem;
-      }
-
-      @media (max-width: 600px) {
-        .ReactStyleguidist-StyleGuide__content {
-          padding: 1.5rem;
-        }
       }
 
       .ReactStyleguidist-Section__root:not(:first-child) {
@@ -112,6 +101,10 @@
         margin: 1rem 0;
       }
 
+      .ReactStyleguidist-Markdown__pre {
+        overflow: auto;
+      }
+
       .ReactStyleguidist-ReactComponent__props {
         padding: 1.5em;
         background: whitesmoke;
@@ -144,9 +137,24 @@
         color: #389040;
       }
 
-      /* Sidebar */
+      /* Layout */
+
+      .ReactStyleguidist-StyleGuide__root.ReactStyleguidist-StyleGuide__hasSidebar {
+        padding-left: 0;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .ReactStyleguidist-StyleGuide__content {
+        max-width: 100vw;
+        padding: 1.5rem;
+        order: 2;
+      }
 
       .ReactStyleguidist-StyleGuide__sidebar {
+        position: static;
+        width: auto;
+        margin-top: 2rem;
         overflow: hidden;
         border: 0;
       }
@@ -154,49 +162,6 @@
       .ReactStyleguidist-StyleGuide__sidebar > div {
         overflow: auto;
         max-height: calc(100vh - 115px);
-      }
-
-      @media (min-width: 600px) {
-        .ReactStyleguidist-StyleGuide__sidebar {
-          background: #43aa4c;
-          color: white;
-          width: 230px;
-          padding-bottom: 60px;
-        }
-
-        body {
-          padding-left: 230px;
-        }
-
-        .ReactStyleguidist-StyleGuide__root.ReactStyleguidist-StyleGuide__hasSidebar {
-          padding-left: 0;
-        }
-
-
-        .ReactStyleguidist-StyleGuide__sidebar .ReactStyleguidist-colors__link {
-          color: white;
-        }
-
-        .ReactStyleguidist-StyleGuide__sidebar .ReactStyleguidist-colors__link:hover {
-          color: whitesmoke;
-        }
-
-        .ReactStyleguidist-StyleGuide__heading {
-          background: #389040;
-          color: white;
-          border: 0;
-        }
-
-        .ReactStyleguidist-StyleGuide__sidebar:before {
-          content: '';
-          position: absolute;
-          bottom: 18px;
-          left: 20px;
-          right: 20px;
-          height: 30px;
-          background: url("https://assets.everydayhero.do/edh-logos/edh-logo-white.svg") no-repeat center;
-          background-size: contain;
-        }
       }
 
       .ReactStyleguidist-StyleGuide__heading small {
@@ -208,14 +173,6 @@
       .ReactStyleguidist-StyleGuide__heading {
         font-weight: 900;
       }
-
-      @media (max-width: 600px) {
-        .ReactStyleguidist-StyleGuide__sidebar {
-          position: relative;
-          margin-top: 2rem;
-        }
-      }
-
 
       /* Hacks */
 
@@ -268,8 +225,7 @@
       }
 
       a.github-link {
-        position: fixed;
-        width: 230px;
+        position: absolute;
         padding: 0 20px;
         top: 0;
         left: 0;
@@ -277,26 +233,6 @@
         height: 52px;
         line-height: 52px;
         opacity: 0;
-      }
-
-      @media (max-width: 600px) {
-        a.github-link {
-          position: absolute;
-          width: 100%;
-        }
-      }
-
-      @media (min-width: 600px) {
-        body:before {
-          content: "";
-          position: fixed;
-          top: 0;
-          left: 0;
-          bottom: 0;
-          width: 230px;
-          background: #43aa4c;
-          background-image: linear-gradient(#389040 52px, #43aa4c 52px);
-        }
       }
 
       /* Icon section */
@@ -354,6 +290,105 @@
         width: 3em;
         font-size: 12px;
         right: 0.25em;
+      }
+
+      /* Isolation mode */
+
+      .ReactStyleguidist-StyleGuide__components > div > .ReactStyleguidist-ReactComponent__root {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        padding: 1rem;
+        background: white;
+        z-index: 100;
+        max-width: 50rem;
+        margin: auto;
+      }
+
+      .ReactStyleguidist-StyleGuide__components > div > .ReactStyleguidist-ReactComponent__root > * {
+        position: relative;
+      }
+
+      .ReactStyleguidist-StyleGuide__components > div > .ReactStyleguidist-ReactComponent__root:before {
+        content: '';
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: white;
+      }
+
+      /* Desktop styles */
+
+      @media (min-width: 750px) {
+        body {
+          padding-left: 230px;
+        }
+
+        body:before {
+          content: "";
+          position: fixed;
+          top: 0;
+          left: 0;
+          bottom: 0;
+          width: 230px;
+          background: #43aa4c;
+          background-image: linear-gradient(#389040 52px, #43aa4c 52px);
+        }
+
+        .ReactStyleguidist-StyleGuide__root.ReactStyleguidist-StyleGuide__hasSidebar {
+          display: block;
+        }
+
+        .ReactStyleguidist-StyleGuide__content {
+          max-width: 50rem;
+          padding: 2rem;
+        }
+
+        .ReactStyleguidist-StyleGuide__sidebar {
+          position: fixed;
+          margin: 0;
+          background: #43aa4c;
+          color: white;
+          width: 230px;
+          padding-bottom: 60px;
+        }
+
+        .ReactStyleguidist-StyleGuide__sidebar .ReactStyleguidist-colors__link {
+          color: white;
+        }
+
+        .ReactStyleguidist-StyleGuide__sidebar .ReactStyleguidist-colors__link:hover {
+          color: whitesmoke;
+        }
+
+        .ReactStyleguidist-StyleGuide__heading {
+          background: #389040;
+          color: white;
+          border: 0;
+        }
+
+        .ReactStyleguidist-StyleGuide__sidebar:before {
+          content: '';
+          position: absolute;
+          bottom: 18px;
+          left: 20px;
+          right: 20px;
+          height: 30px;
+          background: url("https://assets.everydayhero.do/edh-logos/edh-logo-white.svg") no-repeat center;
+          background-size: contain;
+        }
+
+        a.github-link {
+          position: fixed;
+          width: 230px;
+        }
+      }
+
+      .ReactStyleguidist-StyleGuide__components > div > .ReactStyleguidist-ReactComponent__root {
+        padding: 2rem;
       }
 		</style>
 

--- a/styleguide.template.html
+++ b/styleguide.template.html
@@ -6,9 +6,12 @@
 		<title><%=htmlWebpackPlugin.options.title%></title>
 	</head>
 	<body>
-
     <div class="ReactStyleguidist-StyleGuide__content ReactStyleguidist-common__font">
-      <h1 class="page_heading ReactStyleguidist-Section__heading">Constructicon <a href="https://www.npmjs.com/package/constructicon"><img src="https://img.shields.io/npm/v/constructicon.svg?style=flat-square&colorB=43aa4c" alt="npm version"></a></h1>
+      <h1 class="page_heading ReactStyleguidist-Section__heading">
+        Constructicon
+        <a href="https://www.npmjs.com/package/constructicon"><img src="https://img.shields.io/npm/v/constructicon.svg?style=flat-square&colorB=43aa4c" alt="npm version"></a>
+        <a href="https://github.com/everydayhero/constructicon"><img src="https://badge.buildkite.com/670ae004c2a2a3b10f5d875b5093edcb90c18c6a1e7855939e.svg" alt="build status" /></a>
+      </h1>
       <p class='large'>A collection of common patterns used across many Professional Services projects.</p>
       <p>The aim of this library is to provide a toolbelt of components, that will allow us to compose sites together more quickly and consistently.</p>
       <a class='button' href="https://github.com/everydayhero/constructicon">View Project on Github</a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4003,6 +4003,10 @@ mocha@^2.5.3:
     supports-color "1.2.0"
     to-iso-string "0.0.2"
 
+moment@^2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"


### PR DESCRIPTION
**Default:**

By default, an `InputField` of type `date` is rendered.

![picker](https://user-images.githubusercontent.com/729085/36086672-699b2e0a-1019-11e8-86c1-fb718e4dad59.gif)

**Selects:**

On mount, the users' browser is tested for `<input type='date' />` support, and if not, 3 selects for Day/Month/Year are rendered. This can also be set using the `showSelects` prop.

![selects](https://user-images.githubusercontent.com/729085/36086678-714a9a14-1019-11e8-80ab-cffe1463b95d.gif)
