### PR TITLE
Split label and validations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/input-date/index.js
+++ b/source/components/input-date/index.js
@@ -7,6 +7,7 @@ import styles from './styles'
 
 import InputField from '../input-field'
 import InputSelect from '../input-select'
+import Label from '../label'
 
 class InputDate extends Component {
   constructor (props) {
@@ -56,13 +57,13 @@ class InputDate extends Component {
   render () {
     const {
       required = false,
+      classNames,
+      error,
       id,
       label,
       name,
-      error,
-      validations,
-      classNames,
-      styles
+      styles = {},
+      validations
     } = this.props
 
     const {
@@ -78,10 +79,16 @@ class InputDate extends Component {
 
     return showSelects ? (
       <div className={classNames.root} id={id}>
-        <label className={classNames.label}>
-          {label}
-          {required && <span className={classNames.required}>*</span>}
-        </label>
+        {label && (
+          <Label
+            required={required}
+            styles={{
+              root: styles.label,
+              required: styles.required
+            }}>
+            {label}
+          </Label>
+        )}
         <div className={classNames.wrapper}>
           <InputSelect
             {...allowedProps}

--- a/source/components/input-date/index.js
+++ b/source/components/input-date/index.js
@@ -7,6 +7,7 @@ import styles from './styles'
 
 import InputField from '../input-field'
 import InputSelect from '../input-select'
+import InputValidations from '../input-validations'
 import Label from '../label'
 
 class InputDate extends Component {
@@ -122,13 +123,10 @@ class InputDate extends Component {
           />
         </div>
         {error && (
-          <div className={classNames.errors}>
-            {validations.map((error, i) => (
-              <div className={classNames.error} key={i}>
-                {error}
-              </div>
-            ))}
-          </div>
+          <InputValidations
+            styles={{ root: styles.error }}
+            validations={validations}
+          />
         )}
       </div>
     ) : <InputField type='date' {...this.props} />

--- a/source/components/input-date/styles.js
+++ b/source/components/input-date/styles.js
@@ -19,13 +19,6 @@ export default ({
       marginBottom: rhythm(1)
     },
 
-    error: {
-      fontSize: scale(-0.75),
-      fontWeight: 700,
-      marginTop: rhythm(0.5),
-      color: colors.danger
-    },
-
     wrapper: {
       display: 'flex',
       flexWrap: 'nowrap',

--- a/source/components/input-date/styles.js
+++ b/source/components/input-date/styles.js
@@ -19,24 +19,6 @@ export default ({
       marginBottom: rhythm(1)
     },
 
-    label: {
-      display: 'block',
-      fontWeight: 700,
-      fontSize: scale(-0.5),
-      lineHeight: measures.medium,
-      textAlign: 'left',
-      marginBottom: rhythm(0.25),
-      'a': {
-        color: colors.primary,
-        textDecoration: 'underline'
-      }
-    },
-
-    required: {
-      display: 'inline-block',
-      color: colors.danger
-    },
-
     error: {
       fontSize: scale(-0.75),
       fontWeight: 700,

--- a/source/components/input-field/index.js
+++ b/source/components/input-field/index.js
@@ -4,22 +4,25 @@ import omit from 'lodash/omit'
 import withStyles from '../with-styles'
 import styles from './styles'
 
+import Label from '../label'
+
 const isBoolean = (type) => {
   return ['radio', 'checkbox'].indexOf(type) > -1
 }
 
 const InputField = ({
-  type = 'text',
-  required,
-  label,
-  id,
-  name,
-  value,
-  onChange,
-  onBlur,
   classNames,
   error,
+  id,
+  label,
+  name,
+  required,
+  type = 'text',
+  onBlur,
+  onChange,
+  styles = {},
   validations,
+  value,
   ...props
 }) => {
   const propsBlacklist = ['children', 'dirty', 'initial', 'invalid', 'styles', 'touched', 'validators']
@@ -46,10 +49,16 @@ const InputField = ({
   return (
     <div className={`c11n-input-field ${classNames.root}`}>
       {label && (
-        <label className={`c11n-label ${classNames.label}`} id={labelId} htmlFor={inputId}>
+        <Label
+          id={labelId}
+          inputId={inputId}
+          required={required}
+          styles={{
+            root: styles.label,
+            required: styles.required
+          }}>
           {label}
-          {required && <span className={classNames.required} title='Required field'>*</span>}
-        </label>
+        </Label>
       )}
 
       {renderField()}

--- a/source/components/input-field/index.js
+++ b/source/components/input-field/index.js
@@ -4,6 +4,7 @@ import omit from 'lodash/omit'
 import withStyles from '../with-styles'
 import styles from './styles'
 
+import InputValidations from '../input-validations'
 import Label from '../label'
 
 const isBoolean = (type) => {
@@ -64,13 +65,10 @@ const InputField = ({
       {renderField()}
 
       {error && (
-        <div className={classNames.errors}>
-          {validations.map((error, i) => (
-            <div className={classNames.error} key={i}>
-              {error}
-            </div>
-          ))}
-        </div>
+        <InputValidations
+          styles={{ root: styles.error }}
+          validations={validations}
+        />
       )}
     </div>
   )

--- a/source/components/input-field/styles.js
+++ b/source/components/input-field/styles.js
@@ -52,13 +52,6 @@ export default ({
         borderColor: isInvalid ? colors.danger : colors.secondary,
         boxShadow: `0 0 5px ${isInvalid ? colors.danger : colors.secondary}`
       }
-    },
-
-    error: {
-      fontSize: scale(-0.75),
-      fontWeight: 700,
-      marginTop: rhythm(0.5),
-      color: colors.danger
     }
   }
 

--- a/source/components/input-field/styles.js
+++ b/source/components/input-field/styles.js
@@ -29,26 +29,6 @@ export default ({
       marginBottom: rhythm(1)
     },
 
-    label: {
-      display: 'block',
-      fontWeight: 700,
-      fontSize: scale(-0.5),
-      lineHeight: measures.medium,
-      textAlign: 'left',
-      marginBottom: rhythm(0.25),
-
-      a: {
-        color: colors.primary,
-        textDecoration: 'underline'
-      }
-    },
-
-    required: {
-      display: 'inline-block',
-      color: colors.danger,
-      cursor: 'help'
-    },
-
     field: checkbox ? {
       position: 'absolute',
       top: rhythm(0.125),

--- a/source/components/input-select/index.js
+++ b/source/components/input-select/index.js
@@ -7,6 +7,7 @@ import withStyles from '../with-styles'
 import styles from './styles'
 
 import Icon from '../icon'
+import InputValidations from '../input-validations'
 import Label from '../label'
 
 const InputSelect = ({
@@ -97,13 +98,10 @@ const InputSelect = ({
       </div>
 
       {error && (
-        <div className={classNames.errors}>
-          {validations.map((error, i) => (
-            <div className={classNames.error} key={i}>
-              {error}
-            </div>
-          ))}
-        </div>
+        <InputValidations
+          styles={{ root: styles.error }}
+          validations={validations}
+        />
       )}
     </div>
   )

--- a/source/components/input-select/index.js
+++ b/source/components/input-select/index.js
@@ -7,22 +7,23 @@ import withStyles from '../with-styles'
 import styles from './styles'
 
 import Icon from '../icon'
+import Label from '../label'
 
 const InputSelect = ({
+  classNames,
+  error,
+  groupOptions,
+  id,
   label,
   name,
-  id,
-  value,
   options = [],
-  groupOptions,
-  placeholder,
-  onChange,
   onBlur,
+  onChange,
+  placeholder,
   required,
-  error,
+  styles = {},
   validations,
-  classNames,
-  styles,
+  value,
   ...props
 }) => {
   const propsBlacklist = ['children', 'dirty', 'initial', 'invalid', 'styles', 'touched', 'validators']
@@ -62,10 +63,16 @@ const InputSelect = ({
   return (
     <div className={`c11n-input-select ${classNames.root}`}>
       {label && (
-        <label className={`c11n-label ${classNames.label}`} id={labelId} htmlFor={inputId}>
+        <Label
+          id={labelId}
+          inputId={inputId}
+          required={required}
+          styles={{
+            root: styles.label,
+            required: styles.required
+          }}>
           {label}
-          {required && <span className={classNames.required} title='Required field'>*</span>}
-        </label>
+        </Label>
       )}
 
       <div className={classNames.wrapper}>

--- a/source/components/input-select/styles.js
+++ b/source/components/input-select/styles.js
@@ -25,26 +25,6 @@ export default ({
       marginBottom: rhythm(1)
     },
 
-    label: {
-      display: 'block',
-      fontWeight: 700,
-      fontSize: scale(-0.5),
-      lineHeight: measures.medium,
-      textAlign: 'left',
-      marginBottom: rhythm(0.25),
-
-      a: {
-        color: colors.primary,
-        textDecoration: 'underline'
-      }
-    },
-
-    required: {
-      display: 'inline-block',
-      color: colors.danger,
-      cursor: 'help'
-    },
-
     wrapper: {
       position: 'relative',
       'select::-ms-expand': {

--- a/source/components/input-select/styles.js
+++ b/source/components/input-select/styles.js
@@ -90,13 +90,6 @@ export default ({
       top: '50%',
       right: rhythm(0.333),
       transform: 'translateY(-50%)'
-    },
-
-    error: {
-      fontSize: scale(-0.75),
-      fontWeight: 700,
-      marginTop: rhythm(0.5),
-      color: colors.danger
     }
   }
 

--- a/source/components/input-validations/Readme.md
+++ b/source/components/input-validations/Readme.md
@@ -1,0 +1,31 @@
+# Examples
+
+**Standard Use**
+
+```
+<InputValidations
+  validations={[ 'Field is required' ]}
+/>
+```
+
+**Custom styles**
+
+Apply a custom styles object to alter the look. Available elements are:
+
+- `root` - Label element
+- `error` - Individual error strings
+
+```
+var styles = {
+  error: {
+    padding: '1em',
+    backgroundColor: 'red',
+    color: 'white'
+  }
+};
+
+<InputValidations
+  styles={styles}
+  validations={[ 'Field is required' ]}
+/>
+```

--- a/source/components/input-validations/__tests__/InputValidations.js
+++ b/source/components/input-validations/__tests__/InputValidations.js
@@ -1,0 +1,11 @@
+import InputValidations from '..'
+
+describe('InputValidations', () => {
+  it('should render validations', () => {
+    const wrapper = mount(<InputValidations validations={[ 'Field is required', 'Some other error' ]} />)
+    const root = wrapper.find('.c11n-input-validations')
+    const errors = wrapper.find('.c11n-input-validations > div')
+    expect(root.length).to.eql(1)
+    expect(errors.length).to.eql(2)
+  })
+})

--- a/source/components/input-validations/index.js
+++ b/source/components/input-validations/index.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import withStyles from '../with-styles'
+import styles from './styles'
+
+const InputValidations = ({
+  classNames,
+  validations = []
+}) => (
+  <div className={`c11n-input-validations ${classNames.root}`}>
+    {validations.map((error, i) => (
+      <div className={classNames.error} key={i}>
+        {error}
+      </div>
+    ))}
+  </div>
+)
+
+InputValidations.propTypes = {
+  /**
+  * An array of input validations
+  */
+  validations: PropTypes.array,
+
+  /**
+  *
+  */
+  styles: PropTypes.object
+
+}
+
+InputValidations.defaultProps = {}
+
+export default withStyles(styles)(InputValidations)

--- a/source/components/input-validations/styles.js
+++ b/source/components/input-validations/styles.js
@@ -7,7 +7,7 @@ export default ({
   scale,
   rhythm
 }) => {
-  const defaultStyles= {
+  const defaultStyles = {
     root: {
       fontSize: scale(-0.75),
       fontWeight: 700,

--- a/source/components/input-validations/styles.js
+++ b/source/components/input-validations/styles.js
@@ -1,0 +1,23 @@
+import merge from 'lodash/merge'
+
+export default ({
+  styles
+}, {
+  colors,
+  scale,
+  rhythm
+}) => {
+  const defaultStyles= {
+    root: {
+      fontSize: scale(-0.75),
+      fontWeight: 700,
+      color: colors.danger
+    },
+
+    error: {
+      marginTop: rhythm(0.5)
+    }
+  }
+
+  return merge(defaultStyles, styles)
+}

--- a/source/components/label/Readme.md
+++ b/source/components/label/Readme.md
@@ -1,0 +1,30 @@
+# Examples
+
+**Standard Use**
+
+```
+<Label>My Field</Label>
+```
+
+**Required**
+
+```
+<Label required>My Field</Label>
+```
+
+**Custom styles**
+
+Apply a custom styles object to alter the look. Available elements are:
+
+- `root` - Label element
+- `required` - Required label (if present)
+
+```
+var styles = {
+  root: {
+    color: 'green'
+  }
+};
+
+<Label styles={styles}>Green Label</Label>
+```

--- a/source/components/label/__tests__/Label-test.js
+++ b/source/components/label/__tests__/Label-test.js
@@ -1,0 +1,10 @@
+import Label from '..'
+
+describe('Label', () => {
+  it('should render a label', () => {
+    const wrapper = mount(<Label>My Field</Label>)
+    const label = wrapper.find('label')
+    expect(label.length).to.eql(1)
+    expect(label.text()).to.eql('My Field')
+  })
+})

--- a/source/components/label/index.js
+++ b/source/components/label/index.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import withStyles from '../with-styles'
+import styles from './styles'
+
+const Label = ({
+  children,
+  classNames,
+  id,
+  inputId,
+  required
+}) => (
+  <label className={`c11n-label ${classNames.root}`} id={id} htmlFor={inputId}>
+    {children}
+    {required && <span className={classNames.required} title='Required field'>*</span>}
+  </label>
+)
+
+Label.propTypes = {
+  /**
+  * The label
+  */
+  children: PropTypes.any,
+
+  /**
+  * The id of the label
+  */
+  id: PropTypes.string,
+
+  /**
+  * The id of the related input
+  */
+  inputId: PropTypes.string,
+
+  /**
+  * Whether the field is required
+  */
+  required: PropTypes.bool
+}
+
+Label.defaultProps = {}
+
+export default withStyles(styles)(Label)

--- a/source/components/label/styles.js
+++ b/source/components/label/styles.js
@@ -1,0 +1,34 @@
+import merge from 'lodash/merge'
+
+export default ({
+  styles
+}, {
+  colors,
+  measures,
+  rhythm,
+  scale
+}) => {
+  const defaultStyles= {
+    root: {
+      display: 'block',
+      fontWeight: 700,
+      fontSize: scale(-0.5),
+      lineHeight: measures.medium,
+      textAlign: 'left',
+      marginBottom: rhythm(0.25),
+
+      a: {
+        color: colors.primary,
+        textDecoration: 'underline'
+      }
+    },
+
+    required: {
+      display: 'inline-block',
+      color: colors.danger,
+      cursor: 'help'
+    }
+  }
+
+  return merge(defaultStyles, styles)
+}

--- a/source/components/label/styles.js
+++ b/source/components/label/styles.js
@@ -8,7 +8,7 @@ export default ({
   rhythm,
   scale
 }) => {
-  const defaultStyles= {
+  const defaultStyles = {
     root: {
       display: 'block',
       fontWeight: 700,

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -39,6 +39,7 @@ module.exports = {
         path.resolve(__dirname, 'source/components/input-field', 'index.js'),
         path.resolve(__dirname, 'source/components/input-select', 'index.js'),
         path.resolve(__dirname, 'source/components/input-date', 'index.js'),
+        path.resolve(__dirname, 'source/components/input-validations', 'index.js'),
         path.resolve(__dirname, 'source/components/label', 'index.js'),
         path.resolve(__dirname, 'source/components/search-form', 'index.js')
       ])

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -39,6 +39,7 @@ module.exports = {
         path.resolve(__dirname, 'source/components/input-field', 'index.js'),
         path.resolve(__dirname, 'source/components/input-select', 'index.js'),
         path.resolve(__dirname, 'source/components/input-date', 'index.js'),
+        path.resolve(__dirname, 'source/components/label', 'index.js'),
         path.resolve(__dirname, 'source/components/search-form', 'index.js')
       ])
     },


### PR DESCRIPTION
Decided to do this in it's own PR as it is completely backwards compatible

- new Label component
- new InputValidations component
- hooked up InputField, InputDate and InputSelect to use them
- those changes on the props are just me re-organising them alphabetically 😬 

Closes https://github.com/everydayhero/constructicon/issues/32