### PR TITLE
Make URL based meta properties work with either an object or string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/input-search/__tests__/InputSearch-test.js
+++ b/source/components/input-search/__tests__/InputSearch-test.js
@@ -1,6 +1,6 @@
 import InputSearch from '..'
 
-describe.only('InputSearch', () => {
+describe('InputSearch', () => {
   it('fires the onSearch callback when values are user searches', (done) => {
     const onSearch = sinon.spy()
     const wrapper = mount(

--- a/source/components/meta/index.js
+++ b/source/components/meta/index.js
@@ -17,6 +17,17 @@ const Meta = ({
   favicon,
   appleTouchIcon
 }) => {
+  const getURL = (value) => {
+    switch (typeof value) {
+      case 'object':
+        return value.url
+      case 'string':
+        return value
+      default:
+        return undefined
+    }
+  }
+
   const meta = [
     { 'name': 'description', 'content': description },
     { 'name': 'keywords', 'content': keywords },
@@ -24,14 +35,14 @@ const Meta = ({
     { 'property': 'og:type', 'content': ogType },
     { 'property': 'og:title', 'content': ogTitle },
     { 'property': 'og:description', 'content': ogDescription },
-    { 'property': 'og:image', 'content': ogImage },
-    { 'property': 'og:url', 'content': ogUrl || url }
+    { 'property': 'og:image', 'content': getURL(ogImage) },
+    { 'property': 'og:url', 'content': getURL(ogUrl) || getURL(url) }
   ]
 
   const links = [
-    { 'rel': 'canonical', 'href': url },
-    { 'rel': 'shortcut icon', 'href': favicon },
-    { 'rel': 'apple-touch-icon', 'href': appleTouchIcon }
+    { 'rel': 'canonical', 'href': getURL(url) },
+    { 'rel': 'shortcut icon', 'href': getURL(favicon) },
+    { 'rel': 'apple-touch-icon', 'href': getURL(appleTouchIcon) }
   ]
 
   return (
@@ -52,11 +63,11 @@ Meta.propTypes = {
   ogType: PropTypes.string,
   ogTitle: PropTypes.string,
   ogDescription: PropTypes.string,
-  ogImage: PropTypes.string,
-  ogUrl: PropTypes.string,
-  url: PropTypes.string,
-  favicon: PropTypes.string,
-  appleTouchIcon: PropTypes.string
+  ogImage: PropTypes.oneOfType([ PropTypes.string, PropTypes.object ]),
+  ogUrl: PropTypes.oneOfType([ PropTypes.string, PropTypes.object ]),
+  url: PropTypes.oneOfType([ PropTypes.string, PropTypes.object ]),
+  favicon: PropTypes.oneOfType([ PropTypes.string, PropTypes.object ]),
+  appleTouchIcon: PropTypes.oneOfType([ PropTypes.string, PropTypes.object ])
 }
 
 export default Meta


### PR DESCRIPTION
This will now work with the structure we get back from Prismic since recent changes to prismic-utils, but is completely backwards compatible.

I originally just tried `favicon.url || favicon`, but it didn't work as I had hoped. It required defaulting the favicon (and other similar props) to an empty object, but it meant if it wasn't passed through, `favicon.url || favicon` would resolve to an empty object, which react-helmet does not like, and errored. So that is my I implemented the `getURL` function.

Closes https://github.com/everydayhero/constructicon/issues/94