### PR TITLE
Build fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,7 @@ var otherFiles = [
 */
 gulp.task('npm-prep-components', function() {
   return gulp.src(componentsFiles)
-    .pipe(replace('../..', '..'))
+    .pipe(replace('../../lib', '../lib'))
     .pipe(gulp.dest(npmDir))
 })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Only alter the paths for references to the `lib` directory, as it is the only other directory and the only one we need to adjust the path for.