### PR TITLE
Leaderboard style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/leaderboard-item/styles.js
+++ b/source/components/leaderboard-item/styles.js
@@ -2,7 +2,8 @@ import merge from 'lodash/merge'
 
 export default ({
   rank,
-  styles
+  styles,
+  subtitle
 }, {
   measures,
   rhythm,
@@ -38,6 +39,7 @@ export default ({
       display: 'flex',
       alignItems: 'center',
       transition: 'opacity 200ms ease',
+      minHeight: rhythm(1.33),
       ':hover': {
         opacity: 0.75
       }
@@ -59,7 +61,7 @@ export default ({
     },
 
     title: {
-      marginBottom: rhythm(0.125),
+      marginBottom: subtitle && rhythm(0.125),
       fontWeight: 700,
       whiteSpace: 'nowrap',
       overflow: 'hidden',


### PR DESCRIPTION
In Site Builder / Supporticon, I am adding support for leaderboard by groups (think leaderboard of schools in 40HF). These don't have images, and when testing, I realised the `LeaderboardItem` component relies on the image to set the height of it's content (see below before/afters). So I have set the height of the content to ensure everything centres nicely regardless of what it passed in.

**Before**

![image](https://user-images.githubusercontent.com/1445686/37072957-bdc29ad8-220f-11e8-8506-7dd480f716f1.png)

**After**

![image](https://user-images.githubusercontent.com/1445686/37072942-aa23f328-220f-11e8-80d8-f4ad927a0c96.png)
