### PR TITLE
Bind input search method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/input-search/index.js
+++ b/source/components/input-search/index.js
@@ -19,6 +19,7 @@ class InputSearch extends Component {
     this.handleKeyDown = this.handleKeyDown.bind(this)
     this.showMore = this.showMore.bind(this)
     this.clearSelection = this.clearSelection.bind(this)
+    this.setActiveItem = this.setActiveItem.bind(this)
 
     if (props.debounce) {
       this.handleChange = debounce(this.handleChange, props.debounce)


### PR DESCRIPTION
Clicking an item was causing a `cannot read props` of undefined, so now binding `this` to the method.