### PR TITLE
Update Heading PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "1.5.18",
+  "version": "1.5.19",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/heading/index.js
+++ b/source/components/heading/index.js
@@ -24,11 +24,7 @@ Heading.propTypes = {
   /**
   * The html to be structured
   */
-  children: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.arrayOf(PropTypes.element),
-    PropTypes.element
-  ]),
+  children: PropTypes.any,
 
   /**
   * The tag to be used for the containing element


### PR DESCRIPTION
PropTypes were complaining when rendering arrays of strings. 

React will complain if you are trying to render invalid children anyway making this PropType kind of redundant.