### PR TITLE
Input search updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/input-search/index.js
+++ b/source/components/input-search/index.js
@@ -176,6 +176,7 @@ class InputSearch extends Component {
         <div className={classNames.fieldWrapper}>
           <input
             aria-labelledby={labelId}
+            autoComplete='off'
             className={classNames.field}
             type={type}
             id={inputId}

--- a/source/components/input-search/index.js
+++ b/source/components/input-search/index.js
@@ -205,29 +205,29 @@ class InputSearch extends Component {
               </div>
             )
           )}
+          {query && (
+            <div className={classNames.results} ref='results'>
+              <Results
+                active={active}
+                classNames={classNames}
+                emptyMessage={emptyMessage}
+                errorMessage={errorMessage}
+                ResultComponent={ResultComponent}
+                results={results}
+                showMore={showMore}
+                selectItem={this.setActiveItem}
+                status={status}
+                toShow={toShow}>
+                {showMore && results.length > toShow && (
+                  <ShowMore
+                    className={classNames.showMore}
+                    onClick={this.showMore}
+                  />
+                )}
+              </Results>
+            </div>
+          )}
         </div>
-        {query && (
-          <div className={classNames.results} ref='results'>
-            <Results
-              active={active}
-              classNames={classNames}
-              emptyMessage={emptyMessage}
-              errorMessage={errorMessage}
-              ResultComponent={ResultComponent}
-              results={results}
-              showMore={showMore}
-              selectItem={this.setActiveItem}
-              status={status}
-              toShow={toShow}>
-              {showMore && results.length > toShow && (
-                <ShowMore
-                  className={classNames.showMore}
-                  onClick={this.showMore}
-                />
-              )}
-            </Results>
-          </div>
-        )}
         {error && (
           <InputValidations
             styles={{ root: styles.error }}


### PR DESCRIPTION
- Remove annoying autocomplete suggestions from input search fields
- Make results relative to the field itself, not the whole field wrapper
 - This meant if there were validations, the results would show below the validations for subsequent searches