### PR TITLE
Autocomplete madness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/input-search/index.js
+++ b/source/components/input-search/index.js
@@ -125,6 +125,7 @@ class InputSearch extends Component {
 
   render () {
     const {
+      autoComplete,
       classNames,
       emptyMessage,
       error,
@@ -176,7 +177,7 @@ class InputSearch extends Component {
         <div className={classNames.fieldWrapper}>
           <input
             aria-labelledby={labelId}
-            autoComplete='off'
+            autoComplete={autoComplete}
             className={classNames.field}
             type={type}
             id={inputId}
@@ -346,10 +347,16 @@ InputSearch.propTypes = {
   /**
   * An array of validation messages to display
   */
-  validations: PropTypes.array
+  validations: PropTypes.array,
+
+  /**
+  * The autocomplete value for the field
+  */
+  autoComplete: PropTypes.string
 }
 
 InputSearch.defaultProps = {
+  autoComplete: 'nope',
   debounce: 500,
   emptyMessage: 'No results found',
   errorMessage: 'There was an unexpected error',


### PR DESCRIPTION
**Problem**

We were seeing some unusual discrepancies in Chrome, between seemingly similar forms/fields. The c11n docs liked `off` while other projects all like a dump value, such as `nope`.

**Solution**

Simple solution for now is to default the autocomplete to `nope`, but make it a prop so if we hit any weird edge cases in the future, we can override them/randomise/whatever.