### PR TITLE
Properly set initial value of boolean form field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/input-field/index.js
+++ b/source/components/input-field/index.js
@@ -3,13 +3,10 @@ import PropTypes from 'prop-types'
 import omit from 'lodash/omit'
 import withStyles from '../with-styles'
 import styles from './styles'
+import { isBoolean } from '../../lib/form'
 
 import InputValidations from '../input-validations'
 import Label from '../label'
-
-const isBoolean = (type) => {
-  return ['radio', 'checkbox'].indexOf(type) > -1
-}
 
 const InputField = ({
   classNames,

--- a/source/components/input-field/styles.js
+++ b/source/components/input-field/styles.js
@@ -1,4 +1,5 @@
 import merge from 'lodash/merge'
+import { isBoolean } from '../../lib/form'
 
 export default ({
   type,
@@ -15,7 +16,7 @@ export default ({
   scale,
   treatments
 }) => {
-  const checkbox = type === 'checkbox' || type === 'radio'
+  const checkbox = isBoolean(type)
   const textarea = type === 'textarea'
   const isInvalid = touched && invalid
 

--- a/source/components/with-form/index.js
+++ b/source/components/with-form/index.js
@@ -3,6 +3,7 @@ import filter from 'lodash/filter'
 import isEmpty from 'lodash/isEmpty'
 import merge from 'lodash/merge'
 import mapValues from 'lodash/mapValues'
+import { isBoolean } from '../../lib/form'
 
 const withForm = (config) => (ComponentToWrap) => (
   class extends Component {
@@ -27,11 +28,15 @@ const withForm = (config) => (ComponentToWrap) => (
       return merge(defaults, supplied)
     }
 
+    initialValue (field) {
+      return isBoolean(field.type) ? false : ''
+    }
+
     initFields (fields) {
       return mapValues(fields, (field, key) => ({
         ...field,
-        value: field.initial || '',
         name: key,
+        value: field.initial || this.initialValue(field),
         onChange: this.handleChange(key),
         onBlur: this.handleChange(key, true)
       }))

--- a/source/lib/form/index.js
+++ b/source/lib/form/index.js
@@ -1,0 +1,4 @@
+
+export const isBoolean = (type) => {
+  return ['radio', 'checkbox'].indexOf(type) > -1
+}


### PR DESCRIPTION
Previously all fields were initially set to `''`.