### PR TITLE
Accordion style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/accordion/Readme.md
+++ b/source/components/accordion/Readme.md
@@ -9,12 +9,12 @@
       <p>Cras mattis consectetur purus sit amet fermentum. Maecenas faucibus mollis interdum. Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam.</p>
     </RichText>
   </Accordion>
-  <Accordion title='Lorem ipsum dolor sit amet, consectetur adipiscing elit?'>
+  <Accordion title='Purus Lorem Nullam?'>
     <RichText>
       <p>Cras mattis consectetur purus sit amet fermentum. Maecenas faucibus mollis interdum. Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam.</p>
     </RichText>
   </Accordion>
-  <Accordion title='Lorem ipsum dolor sit amet, consectetur adipiscing elit?'>
+  <Accordion title='Morbi leo risus, porta ac consectetur ac, vestibulum at eros, fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.?'>
     <RichText>
       <p>Cras mattis consectetur purus sit amet fermentum. Maecenas faucibus mollis interdum. Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam.</p>
     </RichText>

--- a/source/components/accordion/styles.js
+++ b/source/components/accordion/styles.js
@@ -37,6 +37,7 @@ export default ({
       flexBasis: rhythm(gutter),
       display: 'flex',
       alignItems: 'flex-start',
+      flex: `0 0 ${rhythm(1)}`,
       fontSize: scale(-2),
       color: toggled ? colors[color] : colors.lightGrey
     },


### PR DESCRIPTION
Spacing gets cramped when the title stretches the full length or wraps onto a second line.

Before
<img width="725" alt="screen shot 2018-08-23 at 9 57 12 am" src="https://user-images.githubusercontent.com/1445686/44497805-ac544100-a6be-11e8-81a8-91582634826f.png">

After
<img width="726" alt="screen shot 2018-08-23 at 9 58 59 am" src="https://user-images.githubusercontent.com/1445686/44497808-ad856e00-a6be-11e8-862c-7969d53f4642.png">

