### PR TITLE
Remove FB caption and update docs for Twitter share title

### DIFF
--- a/source/components/button-social/index.js
+++ b/source/components/button-social/index.js
@@ -15,13 +15,12 @@ const ButtonSocial = ({
   url,
   title,
   hashtags,
-  caption,
   ...props
 }) => (
   <Button
     background={type}
     tag={share ? 'button' : 'a'}
-    onClick={share && openShareDialog({ type, url, title, hashtags, caption })}
+    onClick={share && openShareDialog({ type, url, title, hashtags })}
     aria-label={type}
     {...props}>
     <Icon name={type} />
@@ -56,9 +55,9 @@ ButtonSocial.propTypes = {
   hashtags: PropTypes.string,
 
   /**
-  * The caption for the Facebook share
+  * The text for a Twitter or Linkedin share
   */
-  caption: PropTypes.string
+  text: PropTypes.string
 }
 
 ButtonSocial.defaultProps = {

--- a/source/components/button-social/openShareDialog.js
+++ b/source/components/button-social/openShareDialog.js
@@ -2,8 +2,8 @@ import defaults from 'lodash/defaults'
 import map from 'lodash/map'
 
 const services = {
-  facebook: ({ url, caption = '' }) => {
-    return `http://www.facebook.com/sharer.php?u=${url}&caption=${caption}`
+  facebook: ({ url }) => {
+    return `http://www.facebook.com/sharer.php?u=${url}`
   },
   twitter: ({ url, title, hashtags = '' }) => {
     return `https://twitter.com/share?url=${url}&text=${title}&hashtags=${hashtags}`


### PR DESCRIPTION
Facebook no longer supports sending a `caption` parameter with the share dialog, so removing here to avoid confusion/disappointment 😿 

I've also added documentation about the `title` param available for Twitter and Linkedin