### PR TITLE
Add ability to opt-out of built-in styles by passing a classNames prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/with-styles/index.js
+++ b/source/components/with-styles/index.js
@@ -9,35 +9,45 @@ import * as defaultTraits from '../../lib/traits'
 const withStyles = (styles, keyframes = {}) => ComponentToWrap => {
   class ConnectStyles extends Component {
     render () {
-      // get current traits and defaults from context
+      // Get current traits and defaults from context
       const { traits = defaultTraits } = this.context
 
-      // build our combined props from the component itself's default props,
-      // the specified default traits, and the actual provided props
+      // Build our combined props from the component itself's default props,
+      // The specified default traits, and the actual provided props
       const combinedProps = {
         ...ComponentToWrap.defaultProps,
         ...this.props
       }
 
-      // add any keyframes
+      // Add any keyframes
       const keyframesIsFunction = typeof keyframes === 'function'
       const keyframesObject = keyframesIsFunction
         ? keyframes(combinedProps, traits)
         : keyframes
       const keyframeNames = addKeyframes(keyframesObject)
 
-      // if styles is a function, call it and pass through our props and traits
+      // Opt out of built-in styles
+      if (typeof this.props.classNames === 'object') {
+        const newProps = {
+          ...combinedProps,
+          styles: {},
+          classNames: this.props.classNames
+        }
+
+        return <ComponentToWrap {...newProps} />
+      }
+
+      // If styles is a function, call it and pass through our props and traits
       const stylesIsFunction = typeof styles === 'function'
       const stylesObject = stylesIsFunction
         ? styles(combinedProps, traits, keyframeNames)
         : styles
-      const classNames = stylesToClasses(stylesObject)
 
-      // build out our final props to be passed down to the original component
+      // Build out our final props to be passed down to the original component
       const newProps = {
         ...combinedProps,
         styles: stylesObject,
-        classNames
+        classNames: stylesToClasses(stylesObject)
       }
 
       return <ComponentToWrap {...newProps} />


### PR DESCRIPTION
There's still work that needs to be done to be able to pass `classNames` to children components where applicable, but I wanted to release this to test it out with the simpler components first.

#### Usage

To opt-out of the built-in styles (and using emotion to generate classes), simply pass in your own `classNames` object with a string for each of the corresponding elements.