### PR TITLE
Ensure overflow hidden removed when modal unmounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/modal/index.js
+++ b/source/components/modal/index.js
@@ -25,6 +25,10 @@ class Modal extends Component {
     }
   }
 
+  componentWillUnmount () {
+    this.calculateDocumentScroll({ isOpen: false })
+  }
+
   calculateDocumentScroll (props) {
     if (!props.enableDocumentScroll) {
       window.document.body.style.overflow = props.isOpen ? 'hidden' : 'auto'


### PR DESCRIPTION
When the `isOpen` prop changes on a modal, it adds/removes `overflow: hidden` on the body to disable/enable scrolling. But if the modal unmounts some other way (e.g. the user is pushed to another route), the `overflow: hidden` isn't removed and scrolling is stuck. So we just need to ensure it is removed whenever the component unmounts.