### PR TITLE
Acceptably Accessible Accordions

### DIFF
--- a/source/components/accordion/index.js
+++ b/source/components/accordion/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import uuid from 'uuid/v1'
 import PropTypes from 'prop-types'
 import Icon from '../icon'
 import compose from '../../lib/compose'
@@ -9,6 +10,7 @@ import styles from './styles'
 const Accordion = ({
   children,
   title,
+  id = uuid(),
   opened,
   closed,
   toggled,
@@ -16,11 +18,25 @@ const Accordion = ({
   classNames
 }) => (
   <div className={`c11n-accordion ${classNames.root}`}>
-    <div className={classNames.head} onClick={onToggle}>
+    <button
+      id={`${id}-title`}
+      aria-controls={`${id}-body`}
+      aria-expanded={toggled}
+      className={classNames.head}
+      onClick={onToggle}
+    >
       <div className={classNames.toggle}>{toggled ? opened : closed}</div>
       <div className={classNames.title}>{title}</div>
+    </button>
+    <div
+      aria-labelledby={`${id}-title`}
+      role='region'
+      id={`${id}-body`}
+      hidden={!toggled}
+      className={classNames.body}
+    >
+      {children}
     </div>
-    <div className={classNames.body}>{children}</div>
   </div>
 )
 
@@ -59,6 +75,11 @@ Accordion.propTypes = {
    * Opens the accordion by default
    */
   toggled: PropTypes.bool,
+
+  /**
+   * DOM ID
+   */
+  id: PropTypes.string,
 
   /**
    * Icon to show when the panel is open

--- a/source/components/accordion/styles.js
+++ b/source/components/accordion/styles.js
@@ -13,6 +13,7 @@ export default (
 
   const defaultStyles = {
     root: {
+      position: 'relative',
       paddingTop: rhythm(0.5),
       paddingBottom: rhythm(0.5),
       ...borderStyles
@@ -20,9 +21,20 @@ export default (
 
     head: {
       display: 'flex',
+      width: '100%',
       alignItems: 'center',
       ...justifyContent('flex-start'),
-      cursor: 'pointer'
+      cursor: 'pointer',
+      '&:focus:after': {
+        content: '""',
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        boxShadow: `0 0 1rem ${colors.shade}`,
+        pointerEvents: 'none'
+      }
     },
 
     toggle: {

--- a/source/components/rich-text/styles.js
+++ b/source/components/rich-text/styles.js
@@ -52,10 +52,10 @@ export default (
       fontSize: scale(size + 1)
     },
     '& blockquote:before': {
-      content: 'open-quote'
+      content: '"open-quote"'
     },
     '& blockquote:after': {
-      content: 'close-quote'
+      content: '"close-quote"'
     },
 
     '& img': {


### PR DESCRIPTION
AAA... get it? 🥁

Follows [this guide](https://www.w3.org/TR/wai-aria-practices/examples/accordion/accordion.html). Adds some keyboard navigation depending on browser support, and has the aria props for screen readers. The following is using `Tab` (plus `Shift + Tab`) and `Space`:

![accordion](https://user-images.githubusercontent.com/729085/56633533-e50b4680-66a1-11e9-8d0f-4598bb07b877.gif)
