### PR TITLE
Ensure server CSS only applied to content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/lib/renderDocument/index.js
+++ b/source/lib/renderDocument/index.js
@@ -65,7 +65,7 @@ export const Document = ({
 
 export const renderDocument = ({
   assets,
-  content,
+  content = '',
   state = {},
   DocumentComponent = Document
 }) => {
@@ -74,16 +74,14 @@ export const renderDocument = ({
 
   return (
     '<!doctype html>' +
-    renderStylesToString(
-      renderToStaticMarkup(
-        createElement(DocumentComponent, {
-          head: Helmet.rewind(),
-          styles,
-          scripts,
-          content,
-          state
-        })
-      )
+    renderToStaticMarkup(
+      createElement(DocumentComponent, {
+        head: Helmet.rewind(),
+        styles,
+        scripts,
+        content: renderStylesToString(content),
+        state
+      })
     )
   )
 }


### PR DESCRIPTION
My only complaint around emotion is the way it renders it's server CSS inline in various places, which can cause some weird headaches, like the below...

**Problem**

Previously, we were calling `renderStylesToString` with the whole rendered document including everything e.g. the head, the state that gets put in the JSON blob etc. It goes through and tries to inject style blocks all over the place where it thinks is correct. The issue was that we had some HTML in our JSON representation of our state, and it was injecting a style block into that HTML, and it wasn't escaping the quotation marks e.g. `<styles data-emotion-css="bla">`, which was breaking the whole site as it couldn't load the state.

**Solution**

We should only be trying to inject styles into the markup that is generated by our app i.e. the content that gets mounted into the app element in our Document component. I also needed to default the content to an empty string so the dev server still worked.