### PR TITLE
Add label to class name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/lib/css/index.js
+++ b/source/lib/css/index.js
@@ -4,7 +4,7 @@ export const stylesToClasses = (styles = {}) =>
   Object.keys(styles).reduce(
     (classNames, styleKey) => ({
       ...classNames,
-      [styleKey]: createClass(styles[styleKey])
+      [styleKey]: createClass({ ...styles[styleKey], label: styleKey })
     }),
     {}
   )


### PR DESCRIPTION
By adding the key as the label param to emotion's createClass, it will prepend that key to all class names, making them easier to debug.

For example, applying this means that for flippy widget, the markup would look something like...

```
<div class="css-root-123">
  <div class="css-front-123">...</div>
  <div class="css-back-123">...</div>
</div>
```