### PR TITLE
Ensure submit button gets submitProps regardless of whether there are other actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/form/index.js
+++ b/source/components/form/index.js
@@ -62,6 +62,7 @@ const Form = ({
               aria-label={submit}
               title={submit}
               type='submit'
+              {...submitProps}
             >
               <span>{submit}</span>
               {icon && renderIcon(icon)}


### PR DESCRIPTION
If you pass other actions in (e.g. Cancel), it doesn't spread the `submitProps` on the submit button. This meant it wasn't getting the necessarily button styling.