### PR TITLE
Accessibility improvements for accordions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/accordion/index.js
+++ b/source/components/accordion/index.js
@@ -13,6 +13,7 @@ const Accordion = ({
   id = uuid(),
   opened,
   closed,
+  label,
   toggled,
   onToggle,
   classNames
@@ -21,8 +22,8 @@ const Accordion = ({
     <button
       id={`${id}-title`}
       aria-controls={`${id}-body`}
-      aria-expanded={toggled}
-      aria-label={title}
+      aria-expanded={!!toggled}
+      aria-label={label || title}
       className={classNames.head}
       onClick={onToggle}
     >
@@ -51,6 +52,11 @@ Accordion.propTypes = {
    * The title of the section
    */
   title: PropTypes.any.isRequired,
+
+  /**
+   * Labels the accordion title
+   */
+  label: PropTypes.string,
 
   /**
    * The size of the gutter to be passed through rhythm


### PR DESCRIPTION
A couple of very small changes:

* `title` is often a react component, so `aria-label` is set to `[object Object]`, so I've added a `label` prop which can be provided to give a simple text version of the accordion item
* `aria-expanded` is not initially set at all, because toggled is `undefined`, so now it will default to `false`, meaning the attribute is added