### PR TITLE
Leaderboard accessibility improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/leaderboard-item/index.js
+++ b/source/components/leaderboard-item/index.js
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useState } from 'react'
+import uuid from 'uuid/v4'
 import PropTypes from 'prop-types'
 import withStyles from '../with-styles'
 import styles from './styles'
@@ -16,24 +17,67 @@ const LeaderboardItem = ({
   title,
   tag: Tag
 }) => {
+  const [id] = useState(uuid())
+
   return (
     <Tag className={`c11n-leaderboard-item ${classNames.root}`}>
       <LinkTag
+        aria-describedby={`${id}-rank ${id}-title ${id}-subtitle ${id}-amount`}
+        id={id}
         href={href}
         target={target}
         rel={target === '_blank' ? 'noopener' : undefined}
         {...linkProps}
       >
         <div className={classNames.link}>
-          {rank && <div className={classNames.rank}>{rank}</div>}
+          {rank && (
+            <div
+              aria-hidden
+              id={`${id}-rank`}
+              for={id}
+              className={classNames.rank}
+            >
+              {rank}
+            </div>
+          )}
           {image && (
-            <img src={image} alt={title} className={classNames.image} />
+            <img
+              src={image}
+              alt={title}
+              aria-hidden
+              className={classNames.image}
+            />
           )}
           <div className={classNames.info}>
-            <div className={classNames.title}>{title}</div>
-            {subtitle && <div className={classNames.subtitle}>{subtitle}</div>}
+            <div
+              aria-hidden
+              id={`${id}-title`}
+              for={id}
+              className={classNames.title}
+            >
+              {title}
+            </div>
+            {subtitle && (
+              <div
+                aria-hidden
+                id={`${id}-subtitle`}
+                for={id}
+                className={classNames.subtitle}
+              >
+                {subtitle}
+              </div>
+            )}
           </div>
-          {amount && <div className={classNames.amount}>{amount}</div>}
+          {amount && (
+            <div
+              aria-hidden
+              id={`${id}-amount`}
+              for={id}
+              className={classNames.amount}
+            >
+              {amount}
+            </div>
+          )}
         </div>
       </LinkTag>
     </Tag>

--- a/source/components/leaderboard-item/styles.js
+++ b/source/components/leaderboard-item/styles.js
@@ -26,7 +26,6 @@ export default (
       color: foreground && colors[foreground],
       border: borderWidth && `${borderWidth}px solid ${colors[borderColor]}`,
       borderRadius: radius && rhythm(radiuses[radius]),
-      fontSize: scale(-1),
       breakInside: 'avoid',
       listStyle: 'none',
       ...treatments.leaderboardItem
@@ -55,8 +54,8 @@ export default (
 
     image: {
       flex: '0 0 auto',
-      width: rhythm(1.25),
-      height: rhythm(1.25),
+      width: rhythm(1.5),
+      height: rhythm(1.5),
       backgroundColor: 'rgba(0,0,0,0.125)',
       border: '2px solid rgba(0,0,0,0.25)',
       borderRadius: rhythm(radiuses[avatarRadius]),
@@ -80,7 +79,7 @@ export default (
 
     subtitle: {
       lineHeight: measures.medium,
-      fontSize: '0.75em',
+      fontSize: '0.875em',
       opacity: 0.7,
       whiteSpace: 'nowrap',
       overflow: 'hidden',


### PR DESCRIPTION
1. Bumped up the size from scale(-1) to something a little more readably by default
2. Use aria-describedby to group items and allow screen readers to properly read block links such as these leaderboard items

![image](https://user-images.githubusercontent.com/1445686/86080392-22553a80-bad6-11ea-8778-f677b6698b07.png)
