### PR TITLE
Use dependency for ticker

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-onclickoutside": "^6.9.0",
     "react-slick": "^0.26.1",
     "react-slider": "^1.0.7",
+    "react-ticker": "^1.2.2",
     "sanitize-html": "^1.24.0"
   },
   "devDependencies": {

--- a/source/components/ticker/__tests__/Ticker-test.js
+++ b/source/components/ticker/__tests__/Ticker-test.js
@@ -5,23 +5,14 @@ import { colors } from '../../../lib/traits'
 describe('Ticker', () => {
   it('renders a simple ticker', () => {
     const wrapper = mount(<Ticker label='Label' items={['Example item']} />)
-    const ticker = wrapper.find('Ticker')
+    const ticker = wrapper.find('Ticker').first()
     const labelClass = ticker.prop('classNames').label
-    const itemsClass = ticker.prop('classNames').items
     expect(wrapper.find(`.${labelClass}`).text()).to.eql('Label')
-    expect(wrapper.find(`.${itemsClass}`).text()).to.contain('Example item')
-  })
-
-  it('renders items containing elements', () => {
-    const wrapper = mount(<Ticker items={[<div>Hello</div>]} />)
-    const ticker = wrapper.find('Ticker')
-    const itemsClass = ticker.prop('classNames').items
-    expect(wrapper.find(`.${itemsClass}`).text()).to.contain('Hello')
   })
 
   it('allows us to set the background color', () => {
     const wrapper = mount(<Ticker background='secondary' items={['Test']} />)
-    const ticker = wrapper.find('Ticker')
+    const ticker = wrapper.find('Ticker').first()
     const styles = ticker.prop('styles')
     expect(styles.root.backgroundColor).to.eql(colors.secondary)
   })

--- a/source/components/ticker/index.js
+++ b/source/components/ticker/index.js
@@ -1,20 +1,54 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import withStyles from '../with-styles'
-import styles, { keyframes } from './styles'
+import styles from './styles'
 
-const Ticker = ({ classNames, label, items = [] }) => (
-  <div className={`c11n-ticker ${classNames.root}`}>
-    <ul className={classNames.items}>
-      {items.map((item, index) => (
-        <li className={classNames.item} key={index}>
-          {item}
-        </li>
-      ))}
-    </ul>
-    {label && <div className={classNames.label}>{label}</div>}
-  </div>
-)
+import BaseTicker from 'react-ticker'
+
+const Ticker = ({
+  classNames,
+  direction,
+  items = [],
+  label,
+  offset,
+  pauseOnHover,
+  speed
+}) => {
+  const [move, setMove] = useState(true)
+  const speeds = {
+    snail: 5,
+    slow: 7.5,
+    medium: 10,
+    fast: 12.5,
+    cheetah: 20
+  }
+
+  return (
+    <div
+      className={`c11n-ticker ${classNames.root}`}
+      onMouseOver={() => pauseOnHover && setMove(false)}
+      onMouseLeave={() => setMove(true)}
+    >
+      <BaseTicker
+        direction={direction}
+        speed={speeds[speed]}
+        move={move}
+        offset={offset}
+      >
+        {() => (
+          <ul className={classNames.items}>
+            {items.map((item, index) => (
+              <li className={classNames.item} key={index}>
+                {item}
+              </li>
+            ))}
+          </ul>
+        )}
+      </BaseTicker>
+      {label && <div className={classNames.label}>{label}</div>}
+    </div>
+  )
+}
 
 Ticker.propTypes = {
   /**
@@ -26,6 +60,16 @@ Ticker.propTypes = {
    * The color of the text
    */
   foreground: PropTypes.string,
+
+  /**
+   * The scrolling direction
+   */
+  direction: PropTypes.oneOf(['toLeft', 'toRight']),
+
+  /**
+   * The height (passed to rhythm)
+   */
+  height: PropTypes.number,
 
   /**
    * Items to display in animated scroll
@@ -48,9 +92,19 @@ Ticker.propTypes = {
   labelForeground: PropTypes.string,
 
   /**
+   * Ticker offset
+   */
+  offset: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * Pause ticker on hover?
+   */
+  pauseOnHover: PropTypes.bool,
+
+  /**
    * Animation speed
    */
-  speed: PropTypes.oneOf(['snail', 'slow', 'medium', 'fast']),
+  speed: PropTypes.oneOf(['snail', 'slow', 'medium', 'fast', 'cheetah']),
 
   /**
    * Custom styles to be applied
@@ -61,10 +115,14 @@ Ticker.propTypes = {
 Ticker.defaultProps = {
   background: 'shade',
   foreground: 'dark',
+  direction: 'toLeft',
+  height: 2.5,
   labelBackground: 'primary',
   labelForeground: 'light',
-  speed: 'medium',
+  offset: '100%',
+  pauseOnHover: true,
+  speed: 'slow',
   styles: {}
 }
 
-export default withStyles(styles, keyframes)(Ticker)
+export default withStyles(styles)(Ticker)

--- a/source/components/ticker/styles.js
+++ b/source/components/ticker/styles.js
@@ -1,32 +1,24 @@
 import merge from 'lodash/merge'
 
-const speeds = {
-  snail: 5,
-  slow: 3,
-  medium: 2,
-  fast: 1
-}
-
 export default (
   {
     background,
     foreground,
+    height,
     items = [],
     labelBackground,
     labelForeground,
     spacing,
-    speed,
     styles
   },
-  { colors, rhythm, treatments },
-  keyframes
+  { colors, rhythm, treatments }
 ) =>
   merge(
     {
       root: {
         position: 'relative',
         overflow: 'hidden',
-        height: rhythm(2.5),
+        height: rhythm(height),
         backgroundColor: colors[background],
         color: colors[foreground]
       },
@@ -48,13 +40,9 @@ export default (
       },
 
       items: {
-        position: 'absolute',
-        top: '50%',
-        left: 0,
-        paddingLeft: '100%',
-        animation: `${keyframes.marquee} linear infinite`,
-        whiteSpace: 'nowrap',
-        animationDuration: `${Math.max(10, items.length * speeds[speed])}s`
+        height: rhythm(height),
+        lineHeight: rhythm(height),
+        whiteSpace: 'nowrap'
       },
 
       item: {
@@ -64,14 +52,3 @@ export default (
     },
     styles
   )
-
-export const keyframes = {
-  marquee: {
-    '0%': {
-      transform: 'translate3D(0, -50%, 0)'
-    },
-    '100%': {
-      transform: 'translate3D(-100%, -50%, 0)'
-    }
-  }
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7737,6 +7737,11 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.5.2"
     schedule "^0.5.0"
 
+react-ticker@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-ticker/-/react-ticker-1.2.2.tgz#12cda5ff8266c6fe90ffcd8c58e12ba1596ddf24"
+  integrity sha512-PXUujoPJvajxwOfosuuujlrBUrjgGp4FB4haWFOI25ujhMppW4SuLkiOdQ9AylrWN3yTHWdk2kbQWe3n9SjFGA==
+
 react@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"


### PR DESCRIPTION
This has been a problem for a while: The animation speed for the ticker component can vary wildly depending on the amount of content to scroll through. This is a problem with site builder where the content is very dynamic and there's very little control over the speed.

I've opted to offload the calculations & handling resizing etc to [a library](https://www.npmjs.com/package/react-ticker), which is [pretty small and has no dependencies](https://bundlephobia.com/result?p=react-ticker@1.2.2).