### PR TITLE
Improve accessibility of amounts on metrics and leaderboard items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/leaderboard-item/index.js
+++ b/source/components/leaderboard-item/index.js
@@ -6,6 +6,7 @@ import styles from './styles'
 
 const LeaderboardItem = ({
   amount,
+  amountLabel,
   classNames,
   href,
   image,
@@ -71,6 +72,7 @@ const LeaderboardItem = ({
         {amount && (
           <div
             aria-hidden
+            aria-label={amountLabel}
             id={`${id}-amount`}
             htmlFor={id}
             className={classNames.amount}
@@ -171,6 +173,11 @@ LeaderboardItem.propTypes = {
    * The amount being ranked by
    */
   amount: PropTypes.string,
+
+  /**
+   * The aria-label for the amount e.g. 11 miles for an amount of 11 mi.
+   */
+  amountLabel: PropTypes.string,
 
   /**
    * The custom styles to be applied

--- a/source/components/metric/index.js
+++ b/source/components/metric/index.js
@@ -4,7 +4,15 @@ import Icon from '../icon'
 import withStyles from '../with-styles'
 import styles from './styles'
 
-const Metric = ({ label, amount, icon, tag: Tag, classNames, styles }) => {
+const Metric = ({
+  label,
+  amount,
+  amountLabel,
+  icon,
+  tag: Tag,
+  classNames,
+  styles
+}) => {
   const renderIcon = () => {
     if (typeof icon === 'string') {
       return <Icon name={icon} styles={styles.icon} size={1.5} />
@@ -19,7 +27,11 @@ const Metric = ({ label, amount, icon, tag: Tag, classNames, styles }) => {
     <Tag className={`c11n-metric ${classNames.root}`}>
       {renderIcon()}
       {label && <div className={classNames.label}>{label}</div>}
-      {amount && <div className={classNames.amount}>{amount}</div>}
+      {amount && (
+        <div className={classNames.amount} aria-label={amountLabel}>
+          {amount}
+        </div>
+      )}
     </Tag>
   )
 }
@@ -53,6 +65,11 @@ Metric.propTypes = {
     PropTypes.element,
     PropTypes.func
   ]),
+
+  /**
+   * The aria-label for the amount e.g. 11 miles for an amount of 11 mi.
+   */
+  amountLabel: PropTypes.string,
 
   /**
    * Custom styles to be applied


### PR DESCRIPTION
An amount of `11 mi` is read out by screen readers literally, rather than saying "miles". This first requires a change to the relevant c11n components to accept a screen readable label for the amount to be used as the `aria-label`.