### PR TITLE
Update InputVideo to allow shortened video URLs

### DIFF
--- a/source/components/input-video/index.js
+++ b/source/components/input-video/index.js
@@ -27,22 +27,18 @@ class InputVideo extends React.Component {
       return this.props.onChange('')
     }
 
-    if (videoRegex.test(val)) {
-      Promise.resolve()
-        .then(() => this.setState({ status: 'fetching' }))
-        .then(() => fetchOembedUrl(val))
-        .then(video => {
-          if (video.type !== 'video') {
-            return this.setState({ status: 'failed' })
-          }
+    Promise.resolve()
+      .then(() => this.setState({ status: 'fetching' }))
+      .then(() => fetchOembedUrl(val))
+      .then(video => {
+        if (video.type !== 'video' || !videoRegex.test(video.url)) {
+          return this.setState({ status: 'failed' })
+        }
 
-          this.setState({ video, status: 'fetched' })
-          this.props.onVideoChange && this.props.onVideoChange(video)
-        })
-        .catch(() => this.setState({ status: 'failed' }))
-    } else {
-      this.setState({ status: 'failed' })
-    }
+        this.setState({ video, status: 'fetched' })
+        this.props.onVideoChange && this.props.onVideoChange(video)
+      })
+      .catch(() => this.setState({ status: 'failed' }))
 
     this.props.onChange(val)
   }


### PR DESCRIPTION
Iframely supports a range of URL formats for different providers, but then returns the URL in a consistent format which should match the existing regex we have to test video provider URLs.

For example it [accepts `https://youtu.be/:id`](https://github.com/blackbaud-services/iframely/blob/master/lib/plugins/system/oembed/providers.json#L134) but will return a [`url` value of `https://www.youtube.com/watch?v=:id`](https://github.com/blackbaud-services/iframely/blob/master/lib/plugins/system/oembed/providers.json#L141)

https://iframely.blackbaud.services/iframely?url=https:%2F%2Fyoutu.be%2F0hh6ZbyGloQ&oembed=1

So the change here is to allow any old URL to go off to iframely, then based on what we get back from the API, we check if that meets our requirements before moving on.